### PR TITLE
Parametric acceleration distance and Z-speed limiting

### DIFF
--- a/README
+++ b/README
@@ -20,3 +20,46 @@ Then add a line pointing to your second thermistor table, for example:
 Finally, make sure that the nozzle thermistor table, inside ThermistorTable.h in this case, is defined as "temptable" and that the bed thermistor table is defined as "bedtemptable", and that the number of temps is defined as NUMTEMPS for the heater and BNUMTEMPS for the bed.
 
 There are examples of all these configurations in the configuration.h file. Please look at them before you change anything.
+
+
+Use below code as a startup script for Skeinforge 40 and above..:
+From line G1 Z0.5 F100  it is just a priming routine that I use.. You can delete it if you want to.  If you use set SF multiply to 100/100(cooridinates)  and 1/1 (multiplication)
+
+G90
+G21
+G28 F3600.0
+G92 X0 Y0 E0
+G1 F100	
+G1 Z-250.0
+G92 Z0
+G1 Z1.0 F
+G1 F20
+G1 Z-10.0
+G92 Z0
+G1 F2400
+G1 Y-250.0
+G92 Y0
+G1 Y1.0 F
+G1 F1400
+G1 Y-10.0
+G92 Y0
+G1 F2400
+G1 X-250.0
+G92 X0
+G1 X1.0 F
+G1 F1400
+G1 X-10.0
+G92 X0
+G92 E0 
+G1 Z0.5 F100
+G1 X15 E0.7 F1400
+G92 E0 
+G1 Y15 E0.7
+G92 E0
+G1 X0 Y0 E1
+G92 E0
+G1 Y15 E0.7
+G92 E0
+G1 X15 Y15 E0.7
+G92 E0
+

--- a/Tonokip_Firmware/ThermistorTable_mendelparts.h
+++ b/Tonokip_Firmware/ThermistorTable_mendelparts.h
@@ -29,4 +29,3 @@ short temptable[NUMTEMPS][2] = {
 
 
 #endif
-

--- a/Tonokip_Firmware/configuration.h
+++ b/Tonokip_Firmware/configuration.h
@@ -3,35 +3,51 @@
 
 // NO RS485/EXTRUDER CONTROLLER SUPPORT
 // PLEASE VERIFY PIN ASSIGNMENTS FOR YOUR CONFIGURATION!!!!!!!
-#define MOTHERBOARD 3 // ATMEGA168 = 0, SANGUINO = 1, MOTHERBOARD = 2, MEGA/RAMPS = 3, ATMEGA328 = 4, Gen6 = 5, Sanguinololu = 6
+#define MOTHERBOARD 5 // ATMEGA168 = 0, SANGUINO = 1, MOTHERBOARD = 2, MEGA/RAMPS = 3, ATMEGA328 = 4, Gen6 = 5, Sanguinololu = 6
 
 //Comment out to disable SD support
-#define SDSUPPORT 1
+//#define SDSUPPORT 1
+
+//Min step delay in microseconds. If you are experiencing missing steps, try to raise the delay microseconds, but be aware this
+//may probably prevent the motors from reaching the nominal speed. If you enable this, make sure STEP_DELAY_RATIO is disabled.
+
+#define STEP_DELAY_MICROS 1
+
+//Step delay over interval ratio. If you are still experiencing missing steps, try to uncomment the following line, but be aware this
+//may probably prevent the motors from reaching the nominal speed. If you enable this, make sure STEP_DELAY_MICROS is disabled.
+//#define STEP_DELAY_RATIO 0.25
 
 //Acceleration settings
-float full_velocity_units = 10; // the units between minimum and G1 move feedrate
-float travel_move_full_velocity_units = 10; // used for travel moves
-float min_units_per_second = 35.0; // the minimum feedrate
-float min_constant_speed_units = 2; // the minimum units of an accelerated move that must be done at constant speed
-                                    // Note that if the move is shorter than this value, acceleration won't be perfomed,
-                                    // but will be done at the minimum between min_units_per_seconds and move feedrate speeds.
+
+float min_units_per_second = 25.0; // the minimum feedrate
+//float min_constant_speed_units = 2; // the minimum units of an accelerated move that must be done at constant speed
+float acceleration = 17;             // ratio of stepper torque in Nm to weight of accelerated mass in Grams divideb by 1000       Nm/gr/1000
+                                    // lowest of all axis shoul be used.  Dont Forget that the Y-tray gets heavier with //printing. Decrease if stepper cant keep up.
+
 
 // AD595 THERMOCOUPLE SUPPORT UNTESTED... USE WITH CAUTION!!!!
 
 //PID settings:
 //Uncomment the following line to enable PID support. This is untested and could be disastrous. Be careful.
-//#define PIDTEMP 1
+#define PIDTEMP 1
 #ifdef PIDTEMP
 #define PID_MAX 255 // limits current to nozzle
-#define PID_INTEGRAL_DRIVE_MAX 220
-#define PID_PGAIN 180 //100 is 1.0
-#define PID_IGAIN 2 //100 is 1.0
-#define PID_DGAIN 100 //100 is 1.0
+#define PID_INTEGRAL_DRIVE_MAX 255
+#define PID_PGAIN 500//100 is 1.0
+#define PID_IGAIN 95 //100 is 1.0
+#define PID_DGAIN 60 //100 is 1.0
 #endif
 
 //Experimental temperature smoothing - only uncomment this if your temp readings are noisy
-//#define SMOOTHING 1
-//#define SMOOTHFACTOR 16 //best to use a power of two here - determines how many values are averaged together by the smoothing algorithm
+#define SMOOTHING 1
+#define SMOOTHFACTOR 16 //best to use a power of two here - determines how many values are averaged together by the smoothing algorithm
+
+//Experimental watchdog and minimal temp
+//The watchdog waits for the watchperiod in milliseconds whenever an M104 or M109 increases the target temperature
+//If the temperature has not increased at the end of that period, the target temperature is set to zero. It can be reset with another M104/M109
+//#define WATCHPERIOD 5000 //5 seconds
+//The minimal temperature defines the temperature below which the heater will not be enabled
+//#define MINTEMP 130
 
 // Select one of these only to define how the nozzle temp is read.
 #define HEATER_USES_THERMISTOR
@@ -42,17 +58,20 @@ float min_constant_speed_units = 2; // the minimum units of an accelerated move 
 #define BED_USES_THERMISTOR
 //#define BED_USES_AD595
 
+
 // Calibration formulas
 // e_extruded_steps_per_mm = e_feedstock_steps_per_mm * (desired_extrusion_diameter^2 / feedstock_diameter^2)
 // new_axis_steps_per_mm = previous_axis_steps_per_mm * (test_distance_instructed/test_distance_traveled)
 // units are in millimeters or whatever length unit you prefer: inches,football-fields,parsecs etc
 
 //Calibration variables
-float x_steps_per_unit = 80.376;
-float y_steps_per_unit = 80.376;
-float z_steps_per_unit = 3200/1.25;
-float e_steps_per_unit = 16;
+float x_steps_per_unit = 40.075; 
+float y_steps_per_unit = 40.100;
+float z_steps_per_unit = 3394.697;
+float e_steps_per_unit = 442.3027; //30.3 for SF39   390
 float max_feedrate = 200000; //mmm, acceleration!
+
+
 
 //float x_steps_per_unit = 10.047;
 //float y_steps_per_unit = 10.047;
@@ -73,8 +92,8 @@ const bool DISABLE_Z = true;
 const bool DISABLE_E = false;
 
 const bool INVERT_X_DIR = false;
-const bool INVERT_Y_DIR = false;
-const bool INVERT_Z_DIR = true;
+const bool INVERT_Y_DIR = true;
+const bool INVERT_Z_DIR = false;
 const bool INVERT_E_DIR = false;
 
 //Thermistor settings:
@@ -88,22 +107,25 @@ const bool INVERT_E_DIR = false;
 //#include "BedThermistorTable_200k.h"
 
 //Identical thermistors on heater and bed - use this if you have no heated bed or if the thermistors are the same on both:
-#include "ThermistorTable_200k.h"
+//#include "ThermistorTable_200k.h"
 //#include "ThermistorTable_100k.h"
-//#include "ThermistorTable_mendelparts.h"
+#include "ThermistorTable_mendelparts.h"
 #define BNUMTEMPS NUMTEMPS
 #define bedtemptable temptable
 
 //Endstop Settings
 #define ENDSTOPPULLUPS 1
-const bool ENDSTOPS_INVERTING = false;
+const bool ENDSTOPS_INVERTING = true;
 const bool min_software_endstops = false; //If true, axis won't move to coordinates less than zero.
 const bool max_software_endstops = true;  //If true, axis won't move to coordinates greater than the defined lengths below.
-const int X_MAX_LENGTH = 220;
-const int Y_MAX_LENGTH = 220;
+const int X_MAX_LENGTH = 200;
+const int Y_MAX_LENGTH = 200;
 const int Z_MAX_LENGTH = 100;
 
-#define BAUDRATE 115200
+
+
+#define BAUDRATE 57600
+
 
 
 

--- a/Tonokip_Firmware/configuration.h
+++ b/Tonokip_Firmware/configuration.h
@@ -9,27 +9,48 @@
 //#define SDSUPPORT 1
 
 //Min step delay in microseconds. If you are experiencing missing steps, try to raise the delay microseconds, but be aware this
-//may probably prevent the motors from reaching the nominal speed. If you enable this, make sure STEP_DELAY_RATIO is disabled.
+//Enabled for Gen6.  Leave at default 1
 
 #define STEP_DELAY_MICROS 1
 
 //Step delay over interval ratio. If you are still experiencing missing steps, try to uncomment the following line, but be aware this
-//may probably prevent the motors from reaching the nominal speed. If you enable this, make sure STEP_DELAY_MICROS is disabled.
+//Enabled for Gen6.  leave at default 0.25  . Speeds above 120mm/s are drastically slowed down when this is enabled...  
 #define STEP_DELAY_RATIO 0.25
 
+//Comment this to disable ramp acceleration.  
+//Ramp Accleration gives you smoother movements and a more quiet machine.  
+#define RAMP_ACCELERATION 1  // different maximum feedrates do not require different settings.
+
+//Uncomment this to enable exponential acceleration.  Very hard acceleartion alogarithm.
+//#define EXP_ACCELERATION 1  // works good if you have dialed in your settings and you are not changing your feedrates.  
+//different maximum feedrates require different settings..  Otherwise inefficient or too fast.
+
+
 //Acceleration settings
-float full_velocity_units = 3.5; // the units between minimum and G1 move feedrate
-float travel_move_full_velocity_units = 3.5; // used for travel moves
-float min_units_per_second = 35.0; // the minimum feedrate
-float min_constant_speed_units = 0; // the minimum units of an accelerated move that must be done at constant speed
+#ifdef RAMP_ACCELERATION
+float min_units_per_second = 30.0; // the minimum feedrate, this should be about the speed you are printing your perimeters at.
+long max_acceleration_units_per_sq_second = 1000; // Max acceleration in mm/s^2 for printing moves. Higher means faster acceleration. 
+long max_travel_acceleration_units_per_sq_second = 1000; // Max acceleration in mm/s^2 for travel moves. Higher means faster acceleration. 
+#endif
+#ifdef EXP_ACCELERATION
+float full_velocity_units = 5; // the units between minimum and G1 move feedrate  
+// rule of thumb: full_velocity_units=  sqrt(desired maximum feedrate - min_units_per_second)
+float travel_move_full_velocity_units = 10; // used for travel moves.  Use same formula for this..
+
+float min_units_per_second = 35.0; // the minimum feedrate.  Chhose it as about 70% of your fastest "safe" printing speed.
+float min_constant_speed_units = 2; // the minimum units of an accelerated move that must be done at constant speed
                                     // Note that if the move is shorter than this value, acceleration won't be perfomed,
                                     // but will be done at the minimum between min_units_per_seconds and move feedrate speeds.
+#endif
+
+
+
 
 
 // AD595 THERMOCOUPLE SUPPORT UNTESTED... USE WITH CAUTION!!!!
 
 //PID settings:
-//Uncomment the following line to enable PID support. This is untested and could be disastrous. Be careful.
+//These settings work very nice with the Mendel parts hotend. (6 Ohm aluminium block)  Leave PID enabled.
 #define PIDTEMP 1
 #ifdef PIDTEMP
 #define PID_MAX 255 // limits current to nozzle
@@ -39,7 +60,7 @@ float min_constant_speed_units = 0; // the minimum units of an accelerated move 
 #define PID_DGAIN 60 //100 is 1.0
 #endif
 
-//Experimental temperature smoothing - only uncomment this if your temp readings are noisy
+//Experimental temperature smoothing - only uncomment this if your temp readings are noisy.  Absolutely Necessary for Gen6
 #define SMOOTHING 1
 #define SMOOTHFACTOR 16 //best to use a power of two here - determines how many values are averaged together by the smoothing algorithm
 
@@ -47,8 +68,8 @@ float min_constant_speed_units = 0; // the minimum units of an accelerated move 
 //The watchdog waits for the watchperiod in milliseconds whenever an M104 or M109 increases the target temperature
 //If the temperature has not increased at the end of that period, the target temperature is set to zero. It can be reset with another M104/M109
 //#define WATCHPERIOD 5000 //5 seconds
-//The minimal temperature defines the temperature below which the heater will not be enabled
-//#define MINTEMP 130
+//The minimal temperature defines the temperature below which the heater will not be enabled.  Setting it under roomtemperature works as failsafe if the circuit breaks.
+//#define MINTEMP 10
 
 // Select one of these only to define how the nozzle temp is read.
 #define HEATER_USES_THERMISTOR
@@ -65,12 +86,13 @@ float min_constant_speed_units = 0; // the minimum units of an accelerated move 
 // new_axis_steps_per_mm = previous_axis_steps_per_mm * (test_distance_instructed/test_distance_traveled)
 // units are in millimeters or whatever length unit you prefer: inches,football-fields,parsecs etc
 
-//Calibration variables
-float x_steps_per_unit = 40.075; 
-float y_steps_per_unit = 40.100;
-float z_steps_per_unit = 3394.697;
-float e_steps_per_unit = 442.3027; //30.3 for SF39   390
-float max_feedrate = 200000; //mmm, acceleration!
+//Calibration variables..  Settings are the default mendel-parts FiveD values.  Feel free to calibrate and correct.
+float x_steps_per_unit = 40; 
+float y_steps_per_unit = 40;
+float z_steps_per_unit = 3333.592;
+float e_steps_per_unit = 442.3027; // my settings for Skeinforge 40 and higher.
+float max_feedrate = 200000;  // The feedrate the FW will set as upper limit.  Anything higher will be valued down to this. (mm/min)
+float max_z_feedrate = 80; // with this limit in skeinforge can be disabled. (mm/min)
 
 
 
@@ -87,12 +109,12 @@ const bool Z_ENABLE_ON = 0;
 const bool E_ENABLE_ON = 0;
 
 //Disables axis when it's not being used.
-const bool DISABLE_X = false;
+const bool DISABLE_X = false;  
 const bool DISABLE_Y = false;
-const bool DISABLE_Z = true;
+const bool DISABLE_Z = true;  //the only one that is used so infrequently that it is worth disabling. 
 const bool DISABLE_E = false;
 
-const bool INVERT_X_DIR = false;
+const bool INVERT_X_DIR = false;// set to true if you are using x axis belt teeth turned to the outside. 
 const bool INVERT_Y_DIR = true;
 const bool INVERT_Z_DIR = false;
 const bool INVERT_E_DIR = false;
@@ -116,19 +138,16 @@ const bool INVERT_E_DIR = false;
 
 //Endstop Settings
 #define ENDSTOPPULLUPS 1
-const bool ENDSTOPS_INVERTING = true;
+const bool ENDSTOPS_INVERTING = true;  // set to false if using optos from before DEC15, 2010
 const bool min_software_endstops = false; //If true, axis won't move to coordinates less than zero.
 const bool max_software_endstops = true;  //If true, axis won't move to coordinates greater than the defined lengths below.
 const int X_MAX_LENGTH = 200;
 const int Y_MAX_LENGTH = 200;
 const int Z_MAX_LENGTH = 100;
 
-
-
-#define BAUDRATE 57600
+#define BAUDRATE 57600  // Do not forget to change the setting in Repsnapper.  
 
 
 
 
 #endif
-

--- a/Tonokip_Firmware/configuration.h
+++ b/Tonokip_Firmware/configuration.h
@@ -15,14 +15,15 @@
 
 //Step delay over interval ratio. If you are still experiencing missing steps, try to uncomment the following line, but be aware this
 //may probably prevent the motors from reaching the nominal speed. If you enable this, make sure STEP_DELAY_MICROS is disabled.
-//#define STEP_DELAY_RATIO 0.25
+#define STEP_DELAY_RATIO 0.25
 
 //Acceleration settings
-
-float min_units_per_second = 25.0; // the minimum feedrate
-//float min_constant_speed_units = 2; // the minimum units of an accelerated move that must be done at constant speed
-float acceleration = 17;             // ratio of stepper torque in Nm to weight of accelerated mass in Grams divideb by 1000       Nm/gr/1000
-                                    // lowest of all axis shoul be used.  Dont Forget that the Y-tray gets heavier with //printing. Decrease if stepper cant keep up.
+float full_velocity_units = 3.5; // the units between minimum and G1 move feedrate
+float travel_move_full_velocity_units = 3.5; // used for travel moves
+float min_units_per_second = 35.0; // the minimum feedrate
+float min_constant_speed_units = 0; // the minimum units of an accelerated move that must be done at constant speed
+                                    // Note that if the move is shorter than this value, acceleration won't be perfomed,
+                                    // but will be done at the minimum between min_units_per_seconds and move feedrate speeds.
 
 
 // AD595 THERMOCOUPLE SUPPORT UNTESTED... USE WITH CAUTION!!!!
@@ -130,3 +131,4 @@ const int Z_MAX_LENGTH = 100;
 
 
 #endif
+


### PR DESCRIPTION
Acceleration distance is now dependent on the difference of the squares of min_units_per_second  and feedrate.
Acceleration is now a new parameter for tuning.  (can be made to enter motor torque and moved mass to calculate acceleration factor)

Also the problem of Z speed:  I calculate Z speed differently.  This way Repsnapper works as well as SF
