### PR TITLE
Updated M codes at top of file

### DIFF
--- a/Tonokip_Firmware/Tonokip_Firmware.pde
+++ b/Tonokip_Firmware/Tonokip_Firmware.pde
@@ -37,6 +37,8 @@
 // M25  - Pause SD print
 // M26  - Set SD position in bytes (M26 S12345)
 // M27  - Report SD print status
+// M28  - Start SD write (M28 filename.g)
+// M29  - Stop SD write
 // M81  - Turn off Power Supply
 // M82  - Set E codes absolute (default)
 // M83  - Set E codes relative while in Absolute Coordinates (G90) mode


### PR DESCRIPTION
Hi Kliment,

Minor chance but I added the M28, M29 gcode descriptions to the top of the pde file (if you want to include them).

Cheers
Sam
