### PR TITLE
Cleaned up Pins.H:

### DIFF
--- a/Tonokip_Firmware/Tonokip_Firmware.pde
+++ b/Tonokip_Firmware/Tonokip_Firmware.pde
@@ -269,8 +269,10 @@ void setup()
   if(E_ENABLE_PIN > -1) pinMode(E_ENABLE_PIN,OUTPUT);
 
   if(HEATER_0_PIN > -1) pinMode(HEATER_0_PIN,OUTPUT);
+  #ifdef HEATER_1_PIN
   if(HEATER_1_PIN > -1) pinMode(HEATER_1_PIN,OUTPUT);
-  
+  #endif
+
 #ifdef HEATER_USES_MAX6675
   digitalWrite(SCK_PIN,0);
   pinMode(SCK_PIN,OUTPUT);
@@ -1367,14 +1369,16 @@ inline void manage_heater()
   
 
   #if TEMP_1_PIN > -1
+  #ifdef HEATER_1_PIN
     if(current_bed_raw >= target_bed_raw)
     {
       digitalWrite(HEATER_1_PIN,LOW);
     }
-    else 
+    else
     {
       digitalWrite(HEATER_1_PIN,HIGH);
     }
+  #endif
   #endif
 }
 
@@ -1511,8 +1515,10 @@ float analog2tempBed(int raw) {
 inline void kill(byte debug)
 {
   if(HEATER_0_PIN > -1) digitalWrite(HEATER_0_PIN,LOW);
+  #ifdef HEATER_1_PIN  
   if(HEATER_1_PIN > -1) digitalWrite(HEATER_1_PIN,LOW);
-  
+  #endif
+
   disable_x();
   disable_y();
   disable_z();

--- a/Tonokip_Firmware/pins.h
+++ b/Tonokip_Firmware/pins.h
@@ -206,11 +206,20 @@
  #endif
 #endif
 
+//#define __RAMPS_V10__  // for version 1.0
+#define __RAMPS_V11__  // for version 1.1+
+
+#ifdef __RAMPS_V10__
+ #ifdef __RAMPS_V11__
+   #error Oops! is it RAMPS Version 1.0 or RAMPS 1.1, be sure to set only one in pins.h
+ #endif
+#endif
+
 #define X_STEP_PIN         26
 #define X_DIR_PIN          28
 #define X_ENABLE_PIN       24
 #define X_MIN_PIN           3
-#define X_MAX_PIN           -2 //2
+#define X_MAX_PIN          -2 //2
 
 #define Y_STEP_PIN         38
 #define Y_DIR_PIN          40
@@ -228,19 +237,21 @@
 #define E_DIR_PIN          34
 #define E_ENABLE_PIN       30
 
-#define SDPOWER          48
-#define SDSS          53
+#define SDPOWER            48
+#define SDSS               53
 #define LED_PIN            13
 
-//#define FAN_PIN            11 // UNCOMMENT THIS LINE FOR V1.0
-#define FAN_PIN            9 // THIS LINE FOR V1.1
+#ifdef __RAMPS_V10__
+  #define HEATER_0_PIN       12   // FOR V1.0
+  #define FAN_PIN            11   // FOR V1.0
+#else //assume __RAMPS_V11__
+  #define HEATER_0_PIN       10   // FOR V1.1
+  #define HEATER_1_PIN        8   // FOR V1.1
+  #define FAN_PIN             9   // FOR V1.1
+#endif
 
 #define PS_ON_PIN          -1
 #define KILL_PIN           -1
-
-//#define HEATER_0_PIN        12  // UNCOMMENT THIS LINE FOR V1.0
-#define HEATER_0_PIN       10 // THIS LINE FOR V1.1
-#define HEATER_1_PIN       8 // THIS LINE FOR V1.1
 
 #define TEMP_0_PIN          2   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!!
 #define TEMP_1_PIN          1   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!!


### PR DESCRIPTION
  added #define **RAMPS_V10** and **RAMPS_V11** for the two flavors.
  since RAMPS 1.0 has no HEATER_1_PIN, added #ifdefs to Tonokip_Firmware.pde

Signed-off-by: Christopher Keller cakeller98@gmail.com
