### PR TITLE
Heat interval check inside manage_heater()

### DIFF
--- a/Tonokip_Firmware/Tonokip_Firmware.pde
+++ b/Tonokip_Firmware/Tonokip_Firmware.pde
@@ -297,12 +297,8 @@ void loop()
     bufindr = (bufindr + 1)%BUFSIZE;
     }
   //check heater every n milliseconds
-  if((millis() - previous_millis_heater) >= HEATER_CHECK_INTERVAL ) {
       manage_heater();
-      previous_millis_heater = millis();
-      
       manage_inactivity(1);
-    }
   }
 
 
@@ -466,10 +462,7 @@ inline void process_commands()
         if(code_seen('S')) codenum = code_value() * 1000; // seconds to wait
         codenum += millis();  // keep track of when we started waiting
         while(millis()  < codenum ){
-             if((millis() - previous_millis_heater) >= HEATER_CHECK_INTERVAL ) {
-                manage_heater();
-                previous_millis_heater = millis();
-            }
+          manage_heater();
         }
         break;
       case 28: //G28 Home all Axis one at a time
@@ -706,10 +699,7 @@ inline void process_commands()
             Serial.println( analog2temp(current_raw) ); 
             codenum = millis(); 
           }
-          if((millis() - previous_millis_heater) >= HEATER_CHECK_INTERVAL ) {
-            manage_heater();
-            previous_millis_heater = millis();
-          }
+          manage_heater();
         }
         break;
       case 190: // M190 - Wait bed for heater to reach target.
@@ -728,10 +718,7 @@ inline void process_commands()
             Serial.println( analog2temp(current_bed_raw) ); 
             codenum = millis(); 
           }
-          if((millis() - previous_millis_heater) >= HEATER_CHECK_INTERVAL ) {
             manage_heater();
-            previous_millis_heater = millis();
-          }
         }
       #endif
       break;
@@ -976,10 +963,7 @@ void linear_move(unsigned long x_steps_remaining, unsigned long y_steps_remainin
   if(z_steps_remaining) { enable_z(); do_z_step(); z_steps_remaining--; }
   if(e_steps_remaining) { enable_e(); do_e_step(); e_steps_remaining--; }
 
-  
-  previous_millis_heater = millis();
-  
-  //Define variables that are needed for the Bresenham algorithm. Please note that  Z is not currently included in the Bresenham algorithm.
+    //Define variables that are needed for the Bresenham algorithm. Please note that  Z is not currently included in the Bresenham algorithm.
   unsigned int delta_x = x_steps_remaining;
   unsigned long x_interval_nanos;
   unsigned int delta_y = y_steps_remaining;
@@ -1079,12 +1063,8 @@ void linear_move(unsigned long x_steps_remaining, unsigned long y_steps_remainin
   //move until no more steps remain 
   while(x_steps_remaining + y_steps_remaining + z_steps_remaining + e_steps_remaining > 0) {
     //If more that HEATER_CHECK_INTERVAL ms have passed since previous heating check, adjust temp
-    if((millis() - previous_millis_heater) >= HEATER_CHECK_INTERVAL ) {
-      manage_heater();
-      previous_millis_heater = millis();
-      
-      manage_inactivity(2);
-    }
+    manage_heater();
+    manage_inactivity(2);
     #ifdef RAMP_ACCELERATION
     //If acceleration is enabled on this move and we are in the acceleration segment, calculate the current interval
     if (acceleration_enabled && steps_done == 0) {
@@ -1359,91 +1339,94 @@ inline int read_max6675()
 
 inline void manage_heater()
 {
-  #ifdef HEATER_USES_THERMISTOR
-    current_raw = analogRead(TEMP_0_PIN); 
-    // When using thermistor, when the heater is colder than targer temp, we get a higher analog reading than target, 
-    // this switches it up so that the reading appears lower than target for the control logic.
-    current_raw = 1023 - current_raw;
-  #elif defined HEATER_USES_AD595
-    current_raw = analogRead(TEMP_0_PIN);    
-  #elif defined HEATER_USES_MAX6675
-    current_raw = read_max6675();
-  #endif
-  #ifdef SMOOTHING
-  nma = (nma + current_raw) - (nma / SMOOTHFACTOR);
-  current_raw = nma / SMOOTHFACTOR;
-  #endif
-  #ifdef WATCHPERIOD
-    if(watchmillis && millis() - watchmillis > WATCHPERIOD){
-        if(watch_raw + 1 >= current_raw){
-            target_raw = 0;
-            digitalWrite(HEATER_0_PIN,LOW);
-            digitalWrite(LED_PIN,LOW);
-        }else{
-            watchmillis = 0;
+  if((millis() - previous_millis_heater) >= HEATER_CHECK_INTERVAL ) {
+    previous_millis_heater = millis();
+    #ifdef HEATER_USES_THERMISTOR
+      current_raw = analogRead(TEMP_0_PIN); 
+      // When using thermistor, when the heater is colder than targer temp, we get a higher analog reading than target, 
+      // this switches it up so that the reading appears lower than target for the control logic.
+      current_raw = 1023 - current_raw;
+    #elif defined HEATER_USES_AD595
+      current_raw = analogRead(TEMP_0_PIN);    
+    #elif defined HEATER_USES_MAX6675
+      current_raw = read_max6675();
+    #endif
+    #ifdef SMOOTHING
+    nma = (nma + current_raw) - (nma / SMOOTHFACTOR);
+    current_raw = nma / SMOOTHFACTOR;
+    #endif
+    #ifdef WATCHPERIOD
+      if(watchmillis && millis() - watchmillis > WATCHPERIOD){
+          if(watch_raw + 1 >= current_raw){
+              target_raw = 0;
+              digitalWrite(HEATER_0_PIN,LOW);
+              digitalWrite(LED_PIN,LOW);
+          }else{
+              watchmillis = 0;
+          }
+      }
+    #endif
+    #ifdef MINTEMP
+      if(current_raw <= minttemp)
+          target_raw = 0;
+    #endif
+    #ifdef MAXTEMP
+      if(current_raw >= maxttemp) {
+          target_raw = 0;
+      }
+    #endif
+    #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX66675)
+      #ifdef PIDTEMP
+        error = target_raw - current_raw;
+        pTerm = (PID_PGAIN * error) / 100;
+        temp_iState += error;
+        temp_iState = constrain(temp_iState, temp_iState_min, temp_iState_max);
+        iTerm = (PID_IGAIN * temp_iState) / 100;
+        dTerm = (PID_DGAIN * (current_raw - temp_dState)) / 100;
+        temp_dState = current_raw;
+        analogWrite(HEATER_0_PIN, constrain(pTerm + iTerm - dTerm, 0, PID_MAX));
+      #else
+        if(current_raw >= target_raw)
+        {
+          digitalWrite(HEATER_0_PIN,LOW);
+          digitalWrite(LED_PIN,LOW);
         }
-    }
-  #endif
-  #ifdef MINTEMP
-    if(current_raw <= minttemp)
-        target_raw = 0;
-  #endif
-  #ifdef MAXTEMP
-    if(current_raw >= maxttemp) {
-        target_raw = 0;
-    }
-  #endif
-  #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX66675)
-    #ifdef PIDTEMP
-      error = target_raw - current_raw;
-      pTerm = (PID_PGAIN * error) / 100;
-      temp_iState += error;
-      temp_iState = constrain(temp_iState, temp_iState_min, temp_iState_max);
-      iTerm = (PID_IGAIN * temp_iState) / 100;
-      dTerm = (PID_DGAIN * (current_raw - temp_dState)) / 100;
-      temp_dState = current_raw;
-      analogWrite(HEATER_0_PIN, constrain(pTerm + iTerm - dTerm, 0, PID_MAX));
-    #else
-      if(current_raw >= target_raw)
+        else 
+        {
+          digitalWrite(HEATER_0_PIN,HIGH);
+          digitalWrite(LED_PIN,HIGH);
+        }
+      #endif
+    #endif
+    
+    if(millis() - previous_millis_bed_heater < 5000)
+      return;
+    previous_millis_bed_heater = millis();
+  
+    #ifdef BED_USES_THERMISTOR
+  
+      current_bed_raw = analogRead(TEMP_1_PIN);                  
+  
+      // If using thermistor, when the heater is colder than targer temp, we get a higher analog reading than target, 
+      // this switches it up so that the reading appears lower than target for the control logic.
+      current_bed_raw = 1023 - current_bed_raw;
+    #elif defined BED_USES_AD595
+      current_bed_raw = analogRead(TEMP_1_PIN);                  
+  
+    #endif
+    
+  
+    #if TEMP_1_PIN > -1
+      if(current_bed_raw >= target_bed_raw)
       {
-        digitalWrite(HEATER_0_PIN,LOW);
-        digitalWrite(LED_PIN,LOW);
+        digitalWrite(HEATER_1_PIN,LOW);
       }
       else 
       {
-        digitalWrite(HEATER_0_PIN,HIGH);
-        digitalWrite(LED_PIN,HIGH);
+        digitalWrite(HEATER_1_PIN,HIGH);
       }
     #endif
-  #endif
-  
-  if(millis() - previous_millis_bed_heater < 5000)
-    return;
-  previous_millis_bed_heater = millis();
-
-  #ifdef BED_USES_THERMISTOR
-
-    current_bed_raw = analogRead(TEMP_1_PIN);                  
-
-    // If using thermistor, when the heater is colder than targer temp, we get a higher analog reading than target, 
-    // this switches it up so that the reading appears lower than target for the control logic.
-    current_bed_raw = 1023 - current_bed_raw;
-  #elif defined BED_USES_AD595
-    current_bed_raw = analogRead(TEMP_1_PIN);                  
-
-  #endif
-  
-
-  #if TEMP_1_PIN > -1
-    if(current_bed_raw >= target_bed_raw)
-    {
-      digitalWrite(HEATER_1_PIN,LOW);
-    }
-    else 
-    {
-      digitalWrite(HEATER_1_PIN,HIGH);
-    }
-  #endif
+  }
 }
 
 // Takes hot end temperature value as input and returns corresponding raw value. 

--- a/Tonokip_Firmware/Tonokip_Firmware.pde
+++ b/Tonokip_Firmware/Tonokip_Firmware.pde
@@ -1339,94 +1339,94 @@ inline int read_max6675()
 
 inline void manage_heater()
 {
-  if((millis() - previous_millis_heater) >= HEATER_CHECK_INTERVAL ) {
-    previous_millis_heater = millis();
-    #ifdef HEATER_USES_THERMISTOR
-      current_raw = analogRead(TEMP_0_PIN); 
-      // When using thermistor, when the heater is colder than targer temp, we get a higher analog reading than target, 
-      // this switches it up so that the reading appears lower than target for the control logic.
-      current_raw = 1023 - current_raw;
-    #elif defined HEATER_USES_AD595
-      current_raw = analogRead(TEMP_0_PIN);    
-    #elif defined HEATER_USES_MAX6675
-      current_raw = read_max6675();
-    #endif
-    #ifdef SMOOTHING
-    nma = (nma + current_raw) - (nma / SMOOTHFACTOR);
-    current_raw = nma / SMOOTHFACTOR;
-    #endif
-    #ifdef WATCHPERIOD
-      if(watchmillis && millis() - watchmillis > WATCHPERIOD){
-          if(watch_raw + 1 >= current_raw){
-              target_raw = 0;
-              digitalWrite(HEATER_0_PIN,LOW);
-              digitalWrite(LED_PIN,LOW);
-          }else{
-              watchmillis = 0;
-          }
-      }
-    #endif
-    #ifdef MINTEMP
-      if(current_raw <= minttemp)
-          target_raw = 0;
-    #endif
-    #ifdef MAXTEMP
-      if(current_raw >= maxttemp) {
-          target_raw = 0;
-      }
-    #endif
-    #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX66675)
-      #ifdef PIDTEMP
-        error = target_raw - current_raw;
-        pTerm = (PID_PGAIN * error) / 100;
-        temp_iState += error;
-        temp_iState = constrain(temp_iState, temp_iState_min, temp_iState_max);
-        iTerm = (PID_IGAIN * temp_iState) / 100;
-        dTerm = (PID_DGAIN * (current_raw - temp_dState)) / 100;
-        temp_dState = current_raw;
-        analogWrite(HEATER_0_PIN, constrain(pTerm + iTerm - dTerm, 0, PID_MAX));
-      #else
-        if(current_raw >= target_raw)
-        {
-          digitalWrite(HEATER_0_PIN,LOW);
-          digitalWrite(LED_PIN,LOW);
+  if((millis() - previous_millis_heater) < HEATER_CHECK_INTERVAL )
+    return;
+  previous_millis_heater = millis();
+  #ifdef HEATER_USES_THERMISTOR
+    current_raw = analogRead(TEMP_0_PIN); 
+    // When using thermistor, when the heater is colder than targer temp, we get a higher analog reading than target, 
+    // this switches it up so that the reading appears lower than target for the control logic.
+    current_raw = 1023 - current_raw;
+  #elif defined HEATER_USES_AD595
+    current_raw = analogRead(TEMP_0_PIN);    
+  #elif defined HEATER_USES_MAX6675
+    current_raw = read_max6675();
+  #endif
+  #ifdef SMOOTHING
+  nma = (nma + current_raw) - (nma / SMOOTHFACTOR);
+  current_raw = nma / SMOOTHFACTOR;
+  #endif
+  #ifdef WATCHPERIOD
+    if(watchmillis && millis() - watchmillis > WATCHPERIOD){
+        if(watch_raw + 1 >= current_raw){
+            target_raw = 0;
+            digitalWrite(HEATER_0_PIN,LOW);
+            digitalWrite(LED_PIN,LOW);
+        }else{
+            watchmillis = 0;
         }
-        else 
-        {
-          digitalWrite(HEATER_0_PIN,HIGH);
-          digitalWrite(LED_PIN,HIGH);
-        }
-      #endif
-    #endif
-    
-    if(millis() - previous_millis_bed_heater < 5000)
-      return;
-    previous_millis_bed_heater = millis();
-  
-    #ifdef BED_USES_THERMISTOR
-  
-      current_bed_raw = analogRead(TEMP_1_PIN);                  
-  
-      // If using thermistor, when the heater is colder than targer temp, we get a higher analog reading than target, 
-      // this switches it up so that the reading appears lower than target for the control logic.
-      current_bed_raw = 1023 - current_bed_raw;
-    #elif defined BED_USES_AD595
-      current_bed_raw = analogRead(TEMP_1_PIN);                  
-  
-    #endif
-    
-  
-    #if TEMP_1_PIN > -1
-      if(current_bed_raw >= target_bed_raw)
+    }
+  #endif
+  #ifdef MINTEMP
+    if(current_raw <= minttemp)
+        target_raw = 0;
+  #endif
+  #ifdef MAXTEMP
+    if(current_raw >= maxttemp) {
+        target_raw = 0;
+    }
+  #endif
+  #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX66675)
+    #ifdef PIDTEMP
+      error = target_raw - current_raw;
+      pTerm = (PID_PGAIN * error) / 100;
+      temp_iState += error;
+      temp_iState = constrain(temp_iState, temp_iState_min, temp_iState_max);
+      iTerm = (PID_IGAIN * temp_iState) / 100;
+      dTerm = (PID_DGAIN * (current_raw - temp_dState)) / 100;
+      temp_dState = current_raw;
+      analogWrite(HEATER_0_PIN, constrain(pTerm + iTerm - dTerm, 0, PID_MAX));
+    #else
+      if(current_raw >= target_raw)
       {
-        digitalWrite(HEATER_1_PIN,LOW);
+        digitalWrite(HEATER_0_PIN,LOW);
+        digitalWrite(LED_PIN,LOW);
       }
       else 
       {
-        digitalWrite(HEATER_1_PIN,HIGH);
+        digitalWrite(HEATER_0_PIN,HIGH);
+        digitalWrite(LED_PIN,HIGH);
       }
     #endif
-  }
+  #endif
+    
+  if(millis() - previous_millis_bed_heater < 5000)
+    return;
+  previous_millis_bed_heater = millis();
+  
+  #ifdef BED_USES_THERMISTOR
+  
+    current_bed_raw = analogRead(TEMP_1_PIN);                  
+  
+    // If using thermistor, when the heater is colder than targer temp, we get a higher analog reading than target, 
+    // this switches it up so that the reading appears lower than target for the control logic.
+    current_bed_raw = 1023 - current_bed_raw;
+  #elif defined BED_USES_AD595
+    current_bed_raw = analogRead(TEMP_1_PIN);                  
+
+  #endif
+  
+  
+  #if TEMP_1_PIN > -1
+    if(current_bed_raw >= target_bed_raw)
+    {
+      digitalWrite(HEATER_1_PIN,LOW);
+    }
+    else 
+    {
+      digitalWrite(HEATER_1_PIN,HIGH);
+    }
+  #endif
 }
 
 // Takes hot end temperature value as input and returns corresponding raw value. 


### PR DESCRIPTION
Moved the heat interval check to inside the manage_heater function so it is coded only once. manage_heater() can therefore be called from anywhere in the code without affecting the heat interval.
Reduces compile size from 32900 to 32646.
