### PR TITLE
Added parameter support to G28. Fixed format of M114 and M105 to conform to GCode spec.

### DIFF
--- a/Tonokip_Firmware/Tonokip_Firmware.pde
+++ b/Tonokip_Firmware/Tonokip_Firmware.pde
@@ -444,6 +444,7 @@ inline void process_commands()
 {
   unsigned long codenum; //throw away variable
   char *starpos = NULL;
+  boolean axis_set = false;
 
   if(code_seen('G'))
   {
@@ -466,7 +467,12 @@ inline void process_commands()
           manage_heater();
         }
         break;
+        
       case 28: //G28 Home all Axis one at a time
+        axis_set = false;
+        if (code_seen('X')) axis_set = true;
+        if (code_seen('Y')) axis_set = true;
+        if (code_seen('Z')) axis_set = true;
         saved_feedrate = feedrate;
         destination_x = 0;
         current_x = 0;
@@ -479,7 +485,7 @@ inline void process_commands()
         feedrate = 0;
 
     
-        if((X_MIN_PIN > -1 && X_HOME_DIR==-1) || (X_MAX_PIN > -1 && X_HOME_DIR==1)) {
+        if( (axis_set == false || code_seen('X') ) && ((X_MIN_PIN > -1 && X_HOME_DIR==-1) || (X_MAX_PIN > -1 && X_HOME_DIR==1))) {
           current_x = 0;
           destination_x = 1.5 * X_MAX_LENGTH * X_HOME_DIR;
           feedrate = min_units_per_second * 60;
@@ -497,7 +503,7 @@ inline void process_commands()
           feedrate = 0;
         }
         
-        if((Y_MIN_PIN > -1 && Y_HOME_DIR==-1) || (Y_MAX_PIN > -1 && Y_HOME_DIR==1)) {
+        if( (axis_set == false || code_seen('Y') ) &&  ((Y_MIN_PIN > -1 && Y_HOME_DIR==-1) || (Y_MAX_PIN > -1 && Y_HOME_DIR==1))) {
           current_y = 0;
           destination_y = 1.5 * Y_MAX_LENGTH * Y_HOME_DIR;
           feedrate = min_units_per_second * 60;
@@ -515,7 +521,7 @@ inline void process_commands()
           feedrate = 0;
         }
         
-        if((Z_MIN_PIN > -1 && Z_HOME_DIR==-1) || (Z_MAX_PIN > -1 && Z_HOME_DIR==1)) {
+        if(  (axis_set == false || code_seen('Z') ) && ((Z_MIN_PIN > -1 && Z_HOME_DIR==-1) || (Z_MAX_PIN > -1 && Z_HOME_DIR==1))) {
           current_z = 0;
           destination_z = 1.5 * Z_MAX_LENGTH * Z_HOME_DIR;
           feedrate = max_z_feedrate/2;

--- a/Tonokip_Firmware/Tonokip_Firmware.pde
+++ b/Tonokip_Firmware/Tonokip_Firmware.pde
@@ -675,7 +675,7 @@ inline void process_commands()
           bt = analog2tempBed(current_bed_raw);
         #endif
         #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX6675)
-          Serial.print("T:");
+          Serial.print("ok T:");
           Serial.println(tt); 
           #if TEMP_1_PIN > -1
         
@@ -773,13 +773,13 @@ inline void process_commands()
         Serial.println("FIRMWARE_NAME:Sprinter FIRMWARE_URL:http%%3A/github.com/kliment/Sprinter/ PROTOCOL_VERSION:1.0 MACHINE_TYPE:Mendel EXTRUDER_COUNT:1");
         break;
       case 114: // M114
-	Serial.print("X:");
+	Serial.print("C: X:");
         Serial.print(current_x);
-	Serial.print("Y:");
+	Serial.print(" Y:");
         Serial.print(current_y);
-	Serial.print("Z:");
+	Serial.print(" Z:");
         Serial.print(current_z);
-	Serial.print("E:");
+	Serial.print(" E:");
         Serial.println(current_e);
         break;
       #ifdef RAMP_ACCELERATION

--- a/Tonokip_Firmware/configuration.h
+++ b/Tonokip_Firmware/configuration.h
@@ -3,10 +3,10 @@
 
 // NO RS485/EXTRUDER CONTROLLER SUPPORT
 // PLEASE VERIFY PIN ASSIGNMENTS FOR YOUR CONFIGURATION!!!!!!!
-#define MOTHERBOARD 3 // ATMEGA168 = 0, SANGUINO = 1, MOTHERBOARD = 2, MEGA/RAMPS = 3, ATMEGA328 = 4, Gen6 = 5, Sanguinololu = 6
+#define MOTHERBOARD 5 // ATMEGA168 = 0, SANGUINO = 1, MOTHERBOARD = 2, MEGA/RAMPS = 3, ATMEGA328 = 4, Gen6 = 5, Sanguinololu = 6
 
 //Comment out to disable SD support
-#define SDSUPPORT 1
+// #define SDSUPPORT 1
 
 //Min step delay in microseconds. If you are experiencing missing steps, try to raise the delay microseconds, but be aware this
 // If you enable this, make sure STEP_DELAY_RATIO is disabled.
@@ -14,7 +14,7 @@
 
 //Step delay over interval ratio. If you are still experiencing missing steps, try to uncomment the following line, but be aware this
 //If you enable this, make sure STEP_DELAY_MICROS is disabled.
-//#define STEP_DELAY_RATIO 0.25
+#define STEP_DELAY_RATIO 0.25
 
 //Comment this to disable ramp acceleration
 #define RAMP_ACCELERATION 1
@@ -24,12 +24,12 @@
 
 //Acceleration settings
 #ifdef RAMP_ACCELERATION
-float min_units_per_second = 35.0; // the minimum feedrate
+float min_units_per_second = 30.0; // the minimum feedrate
 long max_acceleration_units_per_sq_second = 750; // Max acceleration in mm/s^2 for printing moves
-long max_travel_acceleration_units_per_sq_second = 1500; // Max acceleration in mm/s^2 for travel moves
+long max_travel_acceleration_units_per_sq_second = 1000; // Max acceleration in mm/s^2 for travel moves
 #endif
 #ifdef EXP_ACCELERATION
-float full_velocity_units = 10; // the units between minimum and G1 move feedrate
+float full_velocity_units = 5; // the units between minimum and G1 move feedrate
 float travel_move_full_velocity_units = 10; // used for travel moves
 float min_units_per_second = 35.0; // the minimum feedrate
 float min_constant_speed_units = 2; // the minimum units of an accelerated move that must be done at constant speed
@@ -41,13 +41,13 @@ float min_constant_speed_units = 2; // the minimum units of an accelerated move 
 
 //PID settings:
 //Uncomment the following line to enable PID support. This is untested and could be disastrous. Be careful.
-//#define PIDTEMP 1
+#define PIDTEMP 1
 #ifdef PIDTEMP
 #define PID_MAX 255 // limits current to nozzle
-#define PID_INTEGRAL_DRIVE_MAX 220
-#define PID_PGAIN 180 //100 is 1.0
-#define PID_IGAIN 2 //100 is 1.0
-#define PID_DGAIN 100 //100 is 1.0
+#define PID_INTEGRAL_DRIVE_MAX 255
+#define PID_PGAIN 500 //100 is 1.0
+#define PID_IGAIN 95 //100 is 1.0
+#define PID_DGAIN 60 //100 is 1.0
 #endif
 
 //How often should the heater check for new temp readings, in milliseconds
@@ -55,21 +55,21 @@ float min_constant_speed_units = 2; // the minimum units of an accelerated move 
 #define BED_CHECK_INTERVAL 5000
 
 //Experimental temperature smoothing - only uncomment this if your temp readings are noisy
-//#define SMOOTHING 1
-//#define SMOOTHFACTOR 16 //best to use a power of two here - determines how many values are averaged together by the smoothing algorithm
+#define SMOOTHING 1
+#define SMOOTHFACTOR 16 //best to use a power of two here - determines how many values are averaged together by the smoothing algorithm
 
 //Experimental watchdog and minimal temp
 //The watchdog waits for the watchperiod in milliseconds whenever an M104 or M109 increases the target temperature
 //If the temperature has not increased at the end of that period, the target temperature is set to zero. It can be reset with another M104/M109
 //#define WATCHPERIOD 5000 //5 seconds
 //The minimal temperature defines the temperature below which the heater will not be enabled
-//#define MINTEMP 
+#define MINTEMP 10 
 
 //Experimental max temp
 //When temperature exceeds max temp, your bot will halt.
 //This feature exists to protect your hotend from overheating accidentally, but *NOT* from thermistor short/failure!
 //You should use MINTEMP for thermistor short/failure protection.
-//#define MAXTEMP 275
+#define MAXTEMP 260
 
 // Select one of these only to define how the nozzle temp is read.
 #define HEATER_USES_THERMISTOR
@@ -85,13 +85,13 @@ float min_constant_speed_units = 2; // the minimum units of an accelerated move 
 // new_axis_steps_per_mm = previous_axis_steps_per_mm * (test_distance_instructed/test_distance_traveled)
 // units are in millimeters or whatever length unit you prefer: inches,football-fields,parsecs etc
 
-//Calibration variables
-float x_steps_per_unit = 80.376;
-float y_steps_per_unit = 80.376;
-float z_steps_per_unit = 3200/1.25;
-float e_steps_per_unit = 16;
-float max_feedrate = 200000; //mmm, acceleration!
-float max_z_feedrate = 120;
+//Calibration variables..  Settings are the default mendel-parts FiveD values.  Feel free to calibrate and correct.
+float x_steps_per_unit = 40.188; 
+float y_steps_per_unit = 40.188;
+float z_steps_per_unit = 3333.592;
+float e_steps_per_unit = 442.30; // my settings for Skeinforge 40 and higher.
+float max_feedrate = 200000;  // The feedrate the FW will set as upper limit.  Anything higher will be valued down to this. (mm/min)
+float max_z_feedrate = 80; // with this limit in skeinforge can be disabled. (mm/min)
 
 //float x_steps_per_unit = 10.047;
 //float y_steps_per_unit = 10.047;
@@ -111,9 +111,9 @@ const bool DISABLE_Y = false;
 const bool DISABLE_Z = true;
 const bool DISABLE_E = false;
 
-const bool INVERT_X_DIR = false;
-const bool INVERT_Y_DIR = false;
-const bool INVERT_Z_DIR = true;
+const bool INVERT_X_DIR = true;
+const bool INVERT_Y_DIR = true;
+const bool INVERT_Z_DIR = false;
 const bool INVERT_E_DIR = false;
 
 // Sets direction of endstops when homing; 1=MAX, -1=MIN
@@ -144,11 +144,11 @@ const int Z_HOME_DIR = -1;
 const bool ENDSTOPS_INVERTING = false;
 const bool min_software_endstops = false; //If true, axis won't move to coordinates less than zero.
 const bool max_software_endstops = true;  //If true, axis won't move to coordinates greater than the defined lengths below.
-const int X_MAX_LENGTH = 220;
-const int Y_MAX_LENGTH = 220;
+const int X_MAX_LENGTH = 200;
+const int Y_MAX_LENGTH = 200;
 const int Z_MAX_LENGTH = 100;
 
-#define BAUDRATE 115200
+#define BAUDRATE 57600
 
 
 


### PR DESCRIPTION
Hi Kilment.

Here are 3 commits.

1) To add support for X, Y, Z parameters on G28.

2) The return message for M105 did not start with 'ok' this meant that ReplicatorG hangs as it never received an ok on response to M105.

The return message for M114 did not conform to the reprap wiki gcode spec.  It should start with C: and have spaces between xn.nn yn.nn etc.

3) Unfortunately I also committed changes to my config for my machine first and I could not find a away to exclude this commit in the pull request.  When you merge can you ignore any changes to configuration.h.

Cheers
Geoff Drake
