### PR TITLE
Added RAMPS 1.3 pin definitions

### DIFF
--- a/Tonokip_Firmware/pins.h
+++ b/Tonokip_Firmware/pins.h
@@ -206,11 +206,55 @@
  #endif
 #endif
 
+// uncomment one of the following lines for RAMPS v1.3 or v1.0, comment both for v1.2 or 1.1
+// #define RAMPS_V_1_3
+// #define RAMPS_V_1_0
+
+
+#ifdef RAMPS_V_1_3
+
+#define X_STEP_PIN         54
+#define X_DIR_PIN          55
+#define X_ENABLE_PIN       38
+#define X_MIN_PIN           3
+#define X_MAX_PIN           2
+
+#define Y_STEP_PIN         60
+#define Y_DIR_PIN          61
+#define Y_ENABLE_PIN       56
+#define Y_MIN_PIN          14
+#define Y_MAX_PIN          15
+
+#define Z_STEP_PIN         46
+#define Z_DIR_PIN          48
+#define Z_ENABLE_PIN       62
+#define Z_MIN_PIN          18
+#define Z_MAX_PIN          19
+
+#define E_STEP_PIN         26
+#define E_DIR_PIN          28
+#define E_ENABLE_PIN       24
+
+#define SDPOWER            -1
+#define SDSS               53
+#define LED_PIN            13
+#define FAN_PIN            9
+#define PS_ON_PIN          12
+#define KILL_PIN           -1
+
+#define HEATER_0_PIN       10
+#define HEATER_1_PIN       8
+#define TEMP_0_PIN         13   // ANALOG NUMBERING
+#define TEMP_1_PIN         14   // ANALOG NUMBERING
+
+
+#else // RAMPS_V_1_1 or RAMPS_V_1_2 as default
+
 #define X_STEP_PIN         26
 #define X_DIR_PIN          28
 #define X_ENABLE_PIN       24
 #define X_MIN_PIN           3
-#define X_MAX_PIN          -2    //2
+#define X_MAX_PIN          -1    //2
 
 #define Y_STEP_PIN         38
 #define Y_DIR_PIN          40
@@ -231,28 +275,25 @@
 #define SDPOWER            48
 #define SDSS               53
 #define LED_PIN            13
-
 #define PS_ON_PIN          -1
 #define KILL_PIN           -1
 
-// uncomment the following line for RAMPS V1.0
-// #define RAMPS_V_1_0 
 
-#ifdef RAMPS_V_1_0
+
+#ifdef RAMPS_V_1_0 // RAMPS_V_1_0
   #define HEATER_0_PIN     12    // RAMPS 1.0
   #define HEATER_1_PIN     -1    // RAMPS 1.0
-
   #define FAN_PIN          11    // RAMPS 1.0
 
-#else // RAMPS_V_1_1 as default
+#else // RAMPS_V_1_1 or RAMPS_V_1_2
   #define HEATER_0_PIN     10    // RAMPS 1.1
   #define HEATER_1_PIN      8    // RAMPS 1.1
-
   #define FAN_PIN           9    // RAMPS 1.1
 #endif
 
 #define TEMP_0_PIN          2    // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!!
 #define TEMP_1_PIN          1    // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!!
+#endif
 
 // SPI for Max6675 Thermocouple 
 


### PR DESCRIPTION
I moved the defines for RAMPS version to the beginning of th section. I left default compile to be for version 1.2, uncomment for other versions.
