### PR TITLE
max endstops -1 in RAMPS 1.3

### DIFF
--- a/Tonokip_Firmware/pins.h
+++ b/Tonokip_Firmware/pins.h
@@ -217,19 +217,19 @@
 #define X_DIR_PIN          55
 #define X_ENABLE_PIN       38
 #define X_MIN_PIN           3
-#define X_MAX_PIN           2
+#define X_MAX_PIN          -1   //2 //Max endstops default to disabled "-1", set to commented value to enable.
 
 #define Y_STEP_PIN         60
 #define Y_DIR_PIN          61
 #define Y_ENABLE_PIN       56
 #define Y_MIN_PIN          14
-#define Y_MAX_PIN          15
+#define Y_MAX_PIN          -1   //15
 
 #define Z_STEP_PIN         46
 #define Z_DIR_PIN          48
 #define Z_ENABLE_PIN       62
 #define Z_MIN_PIN          18
-#define Z_MAX_PIN          19
+#define Z_MAX_PIN          -1   //19
 
 #define E_STEP_PIN         26
 #define E_DIR_PIN          28


### PR DESCRIPTION
I set the max endstops -1 in pins.h like other boards since most people do not use max endstops. Having the max endstop pins defined by default has caused confusion. 
