### PR TITLE
Respect HEATER_USES_* when initializing temperature smoothing

### DIFF
--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -133,7 +133,7 @@ float tt = 0, bt = 0;
   int temp_iState_max = 100 * PID_INTEGRAL_DRIVE_MAX / PID_IGAIN;
 #endif
 #ifdef SMOOTHING
-  uint32_t nma = SMOOTHFACTOR * analogRead(TEMP_0_PIN);
+  uint32_t nma = 0;
 #endif
 #ifdef WATCHPERIOD
   int watch_raw = -1000;
@@ -1268,6 +1268,7 @@ inline void manage_heater()
     current_raw = read_max6675();
   #endif
   #ifdef SMOOTHING
+  if (!nma) nma = SMOOTHFACTOR * current_raw;
   nma = (nma + current_raw) - (nma / SMOOTHFACTOR);
   current_raw = nma / SMOOTHFACTOR;
   #endif


### PR DESCRIPTION
Bugfix: smoothed temperature was initialized without respecting HEATER_USES_*
