### PR TITLE
Support for TEMP_RESIDENCY_TIME for M109

### DIFF
--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -140,6 +140,9 @@ char uuid[] = "00000000-0000-0000-0000-000000000000";
 // If the temperature has not increased at the end of that period, the target temperature is set to zero. It can be reset with another M104/M109
 //#define WATCHPERIOD 5000 //5 seconds
 
+// Wait this long after achieving target temperature on M109 before continuing with print (seconds)
+#define TEMP_RESIDENCY_TIME 20
+
 //// The minimal temperature defines the temperature below which the heater will not be enabled
 #define MINTEMP 5
 

--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -16,12 +16,14 @@
 // 2 is 200k thermistor
 // 3 is mendel-parts thermistor
 // 4 is 10k thermistor
-#define THERMISTORHEATER 1
-#define THERMISTORBED 1
+// 5 is Ultimachine
+// 6 is honeywell
+#define THERMISTORHEATER 5
+#define THERMISTORBED 6
 
 //// Calibration variables
 // X, Y, Z, E steps per unit - Metric Prusa Mendel with Wade extruder:
-float axis_steps_per_unit[] = {80, 80, 3200/1.25,700}; 
+float axis_steps_per_unit[] = {32.37655, 32.37655, 642,144.31/2}; 
 // Metric Prusa Mendel with Makergear geared stepper extruder:
 //float axis_steps_per_unit[] = {80,80,3200/1.25,1380}; 
 
@@ -36,7 +38,7 @@ const bool ENDSTOPS_INVERTING = false; //set to true to invert the logic of the 
 #define BAUDRATE 115200
 
 // Comment out (using // at the start of the line) to disable SD support:
-#define SDSUPPORT 1
+//#define SDSUPPORT 1
 
 
 //// ADVANCED SETTINGS - to tweak parameters
@@ -101,7 +103,7 @@ long max_travel_acceleration_units_per_sq_second[] = {500,500,50,500}; // X, Y, 
 // Machine UUID
 // This may be useful if you have multiple machines and wish to identify them by using the M115 command. 
 // By default we set it to zeros.
-char uuid[] = "00000000-0000-0000-0000-000000000000";
+char uuid[] = "00000000-0000-0000-0000-000000000123";
 
 
 //// AD595 THERMOCOUPLE SUPPORT UNTESTED... USE WITH CAUTION!!!!
@@ -119,7 +121,7 @@ char uuid[] = "00000000-0000-0000-0000-000000000000";
 
 // How often should the heater check for new temp readings, in milliseconds
 #define HEATER_CHECK_INTERVAL 500
-#define BED_CHECK_INTERVAL 5000
+#define BED_CHECK_INTERVAL 2000
 // Comment the following line to enable heat management during acceleration
 #define DISABLE_CHECK_DURING_ACC
 #ifndef DISABLE_CHECK_DURING_ACC
@@ -141,7 +143,7 @@ char uuid[] = "00000000-0000-0000-0000-000000000000";
 //#define WATCHPERIOD 5000 //5 seconds
 
 // Wait this long after achieving target temperature on M109 before continuing with print (seconds)
-#define TEMP_RESIDENCY_TIME 20
+//#define TEMP_RESIDENCY_TIME 20
 
 //// The minimal temperature defines the temperature below which the heater will not be enabled
 #define MINTEMP 5
@@ -150,7 +152,7 @@ char uuid[] = "00000000-0000-0000-0000-000000000000";
 // When temperature exceeds max temp, your heater will be switched off.
 // This feature exists to protect your hotend from overheating accidentally, but *NOT* from thermistor short/failure!
 // You should use MINTEMP for thermistor short/failure protection.
-#define MAXTEMP 275
+#define MAXTEMP 250
 
 // Select one of these only to define how the nozzle temp is read.
 #define HEATER_USES_THERMISTOR

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -778,6 +778,23 @@ inline void process_commands()
           }
           manage_heater();
         }
+        // wait extra time before letting the print continue
+        #ifdef TEMP_RESIDENCY_TIME
+        {
+          long residencyStart = millis();
+          codenum = millis();
+          while(millis()-residencyStart<(TEMP_RESIDENCY_TIME*1000)) {
+            if( (millis() - codenum) > 1000 ) //Print Temp Reading every 1 second while heating up.
+            {
+              Serial.print("T:");
+              Serial.println( analog2temp(current_raw) ); 
+              codenum = millis(); 
+            }
+            manage_heater();
+          }
+        }
+        #endif
+        
         break;
       case 190: // M190 - Wait bed for heater to reach target.
       #if TEMP_1_PIN > -1


### PR DESCRIPTION
This helps temps stabilize for a bit before starting a print.  Similar to the feature in Teacup.
