### PR TITLE
M42 and heated bed safety

### DIFF
--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -43,6 +43,7 @@
 // M27  - Report SD print status
 // M28  - Start SD write (M28 filename.g)
 // M29  - Stop SD write
+// M42 - Set output on free pins, on a non pwm pin (over pin 13 on an arduino mega) use S255 to turn it on and S0 to turn it off. Use P to decide the pin (M42 P23 S255) would turn pin 23 on
 // M81  - Turn off Power Supply
 // M82  - Set E codes absolute (default)
 // M83  - Set E codes relative while in Absolute Coordinates (G90) mode
@@ -721,6 +722,31 @@ inline void process_commands()
         //savetosd = false;
         break;
 #endif
+      case 42: //M42 -Change pin status via gcode
+        if (code_seen('S'))
+        {
+          int pin_status = code_value();
+          if (code_seen('P') && pin_status >= 0 && pin_status <= 255)
+          {
+            int pin_number = code_value();
+            for(int i = 0; i < sizeof(sensitive_pins); i++)
+            {
+              if (sensitive_pins[i] == pin_number)
+              {
+                pin_number = -1;
+                break;
+              }
+            }
+            
+            if (pin_number > -1)
+            {              
+              pinMode(pin_number, OUTPUT);
+              digitalWrite(pin_number, pin_status);
+              analogWrite(pin_number, pin_status);
+            }
+          }
+        }
+        break;
       case 104: // M104
         if (code_seen('S')) target_raw = temp2analogh(code_value());
         #ifdef WATCHPERIOD

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -1498,7 +1498,11 @@ void manage_heater()
   #endif
   
   
+  #ifdef MINTEMP
     if(current_bed_raw >= target_bed_raw || current_bed_raw < minttemp)
+  #else
+    if(current_bed_raw >= target_bed_raw)
+  #endif
     {
       WRITE(HEATER_1_PIN,LOW);
     }

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -1498,7 +1498,7 @@ void manage_heater()
   #endif
   
   
-    if(current_bed_raw >= target_bed_raw)
+    if(current_bed_raw >= target_bed_raw || current_bed_raw < minttemp)
     {
       WRITE(HEATER_1_PIN,LOW);
     }

--- a/Sprinter/pins.h
+++ b/Sprinter/pins.h
@@ -495,4 +495,7 @@
 
 #endif
 
+//List of pins which to ignore when asked to change by gcode, 0 and 1 are RX and TX, do not mess with those!
+const int sensitive_pins[] = {0, 1, X_STEP_PIN, X_DIR_PIN, X_ENABLE_PIN, X_MIN_PIN, X_MAX_PIN, Y_STEP_PIN, Y_DIR_PIN, Y_ENABLE_PIN, Y_MIN_PIN, Y_MAX_PIN, Z_STEP_PIN, Z_DIR_PIN, Z_ENABLE_PIN, Z_MIN_PIN, Z_MAX_PIN, E_STEP_PIN, E_DIR_PIN, E_ENABLE_PIN, LED_PIN, PS_ON_PIN, HEATER_0_PIN, HEATER_1_PIN, FAN_PIN, TEMP_0_PIN, TEMP_1_PIN};
+
 #endif


### PR DESCRIPTION
Added M42 to control free pins through gcode

and added MINTEMP to work on the heated bed too, if the thermistor breaks and temperature drops to zero, it is still possible to turn it on, but not off again. With this it won't be able to turn on when temperature is below MINTEMP, which is defined in configuration.h
