### PR TITLE
Change ENDSTOPS_INVERTING to [XYZ]_ENDSTOP_INVERT

### DIFF
--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -32,10 +32,11 @@ float axis_steps_per_unit[] = {80, 80, 3200/1.25,700};
 #define ENDSTOPPULLUPS 1 // Comment this out (using // at the start of the line) to disable the endstop pullup resistors
 // The pullups are needed if you directly connect a mechanical endswitch between the signal and ground pins.
 //If your axes are only moving in one direction, make sure the endstops are connected properly.
-//If your axes move in one direction ONLY when the endstops are triggered, set ENDSTOPS_INVERTING to true here
-cost bool X_ENDSTOP_INVERT = false;//set to true to invert the logic of the endstops
-cost bool Y_ENDSTOP_INVERT = false;//set to true to invert the logic of the endstops
-cost bool Z_ENDSTOP_INVERT = false;//set to true to invert the logic of the endstops
+//If your axes move in one direction ONLY when the endstops are triggered, set [XYZ]_ENDSTOP_INVERT to true here:
+const bool X_ENDSTOP_INVERT = false;
+const bool Y_ENDSTOP_INVERT = false;
+const bool Z_ENDSTOP_INVERT = false;
+
 // This determines the communication speed of the printer
 #define BAUDRATE 115200
 

--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -31,10 +31,11 @@ float axis_steps_per_unit[] = {80, 80, 3200/1.25,700};
 //// Endstop Settings
 #define ENDSTOPPULLUPS 1 // Comment this out (using // at the start of the line) to disable the endstop pullup resistors
 // The pullups are needed if you directly connect a mechanical endswitch between the signal and ground pins.
-const bool ENDSTOPS_INVERTING = false; //set to true to invert the logic of the endstops
 //If your axes are only moving in one direction, make sure the endstops are connected properly.
 //If your axes move in one direction ONLY when the endstops are triggered, set ENDSTOPS_INVERTING to true here
-
+cost bool X_ENDSTOP_INVERT = false;//set to true to invert the logic of the endstops
+cost bool Y_ENDSTOP_INVERT = false;//set to true to invert the logic of the endstops
+cost bool Z_ENDSTOP_INVERT = false;//set to true to invert the logic of the endstops
 // This determines the communication speed of the printer
 #define BAUDRATE 115200
 

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -960,7 +960,7 @@ inline void process_commands()
       	#endif
       	#if (Z_MIN_PIN > -1)
       	Serial.print("z_min:");
-        Serial.print((READ(Z_MIN_PIN)^Z_ENDSTOP_INVERT?"H ":"L ");
+        Serial.print((READ(Z_MIN_PIN)^Z_ENDSTOP_INVERT)?"H ":"L ");
       	#endif
       	#if (Z_MAX_PIN > -1)
       	Serial.print("z_max:");

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -944,27 +944,27 @@ inline void process_commands()
       case 119: // M119
       	#if (X_MIN_PIN > -1)
       	Serial.print("x_min:");
-        Serial.print((READ(X_MIN_PIN)^ENDSTOPS_INVERTING)?"H ":"L ");
+        Serial.print((READ(X_MIN_PIN)^X_ENDSTOP_INVERT)?"H ":"L ");
       	#endif
       	#if (X_MAX_PIN > -1)
       	Serial.print("x_max:");
-        Serial.print((READ(X_MAX_PIN)^ENDSTOPS_INVERTING)?"H ":"L ");
+        Serial.print((READ(X_MAX_PIN)^X_ENDSTOP_INVERT)?"H ":"L ");
       	#endif
       	#if (Y_MIN_PIN > -1)
       	Serial.print("y_min:");
-        Serial.print((READ(Y_MIN_PIN)^ENDSTOPS_INVERTING)?"H ":"L ");
+        Serial.print((READ(Y_MIN_PIN)^Y_ENDSTOP_INVERT)?"H ":"L ");
       	#endif
       	#if (Y_MAX_PIN > -1)
       	Serial.print("y_max:");
-        Serial.print((READ(Y_MAX_PIN)^ENDSTOPS_INVERTING)?"H ":"L ");
+        Serial.print((READ(Y_MAX_PIN)^Y_ENDSTOP_INVERT)?"H ":"L ");
       	#endif
       	#if (Z_MIN_PIN > -1)
       	Serial.print("z_min:");
-        Serial.print((READ(Z_MIN_PIN)^ENDSTOPS_INVERTING)?"H ":"L ");
+        Serial.print((READ(Z_MIN_PIN)^Z_ENDSTOP_INVERT?"H ":"L ");
       	#endif
       	#if (Z_MAX_PIN > -1)
       	Serial.print("z_max:");
-        Serial.print((READ(Z_MAX_PIN)^ENDSTOPS_INVERTING)?"H ":"L ");
+        Serial.print((READ(Z_MAX_PIN)^Z_ENDSTOP_INVERT)?"H ":"L ");
       	#endif
         Serial.println("");
       	break;
@@ -1119,22 +1119,22 @@ inline void linear_move(unsigned long axis_steps_remaining[]) // make linear mov
   else WRITE(E_DIR_PIN,INVERT_E_DIR);
   movereset:
   #if (X_MIN_PIN > -1) 
-    if(!move_direction[0]) if(READ(X_MIN_PIN) != ENDSTOPS_INVERTING) axis_steps_remaining[0]=0;
+    if(!move_direction[0]) if(READ(X_MIN_PIN) != X_ENDSTOP_INVERT) axis_steps_remaining[0]=0;
   #endif
   #if (Y_MIN_PIN > -1) 
-    if(!move_direction[1]) if(READ(Y_MIN_PIN) != ENDSTOPS_INVERTING) axis_steps_remaining[1]=0;
+    if(!move_direction[1]) if(READ(Y_MIN_PIN) != Y_ENDSTOP_INVERT) axis_steps_remaining[1]=0;
   #endif
   #if (Z_MIN_PIN > -1) 
-    if(!move_direction[2]) if(READ(Z_MIN_PIN) != ENDSTOPS_INVERTING) axis_steps_remaining[2]=0;
+    if(!move_direction[2]) if(READ(Z_MIN_PIN) != Z_ENDSTOP_INVERT) axis_steps_remaining[2]=0;
   #endif
   #if (X_MAX_PIN > -1) 
-    if(move_direction[0]) if(READ(X_MAX_PIN) != ENDSTOPS_INVERTING) axis_steps_remaining[0]=0;
+    if(move_direction[0]) if(READ(X_MAX_PIN) != X_ENDSTOP_INVERT) axis_steps_remaining[0]=0;
   #endif
   #if (Y_MAX_PIN > -1) 
-    if(move_direction[1]) if(READ(Y_MAX_PIN) != ENDSTOPS_INVERTING) axis_steps_remaining[1]=0;
+    if(move_direction[1]) if(READ(Y_MAX_PIN) != Y_ENDSTOP_INVERT) axis_steps_remaining[1]=0;
   #endif
   # if(Z_MAX_PIN > -1) 
-    if(move_direction[2]) if(READ(Z_MAX_PIN) != ENDSTOPS_INVERTING) axis_steps_remaining[2]=0;
+    if(move_direction[2]) if(READ(Z_MAX_PIN) != Z_ENDSTOP_INVERT) axis_steps_remaining[2]=0;
   #endif
   
   
@@ -1310,22 +1310,22 @@ inline void linear_move(unsigned long axis_steps_remaining[]) // make linear mov
     //If there are x or y steps remaining, perform Bresenham algorithm
     if(axis_steps_remaining[primary_axis]) {
       #if (X_MIN_PIN > -1) 
-        if(!move_direction[0]) if(READ(X_MIN_PIN) != ENDSTOPS_INVERTING) if(primary_axis==0) break; else if(axis_steps_remaining[0]) axis_steps_remaining[0]=0;
+        if(!move_direction[0]) if(READ(X_MIN_PIN) != X_ENDSTOP_INVERT) if(primary_axis==0) break; else if(axis_steps_remaining[0]) axis_steps_remaining[0]=0;
       #endif
       #if (Y_MIN_PIN > -1) 
-        if(!move_direction[1]) if(READ(Y_MIN_PIN) != ENDSTOPS_INVERTING) if(primary_axis==1) break; else if(axis_steps_remaining[1]) axis_steps_remaining[1]=0;
+        if(!move_direction[1]) if(READ(Y_MIN_PIN) != Y_ENDSTOP_INVERT) if(primary_axis==1) break; else if(axis_steps_remaining[1]) axis_steps_remaining[1]=0;
       #endif
       #if (X_MAX_PIN > -1) 
-        if(move_direction[0]) if(READ(X_MAX_PIN) != ENDSTOPS_INVERTING) if(primary_axis==0) break; else if(axis_steps_remaining[0]) axis_steps_remaining[0]=0;
+        if(move_direction[0]) if(READ(X_MAX_PIN) != X_ENDSTOP_INVERT) if(primary_axis==0) break; else if(axis_steps_remaining[0]) axis_steps_remaining[0]=0;
       #endif
       #if (Y_MAX_PIN > -1) 
-        if(move_direction[1]) if(READ(Y_MAX_PIN) != ENDSTOPS_INVERTING) if(primary_axis==1) break; else if(axis_steps_remaining[1]) axis_steps_remaining[1]=0;
+        if(move_direction[1]) if(READ(Y_MAX_PIN) != Y_ENDSTOP_INVERT) if(primary_axis==1) break; else if(axis_steps_remaining[1]) axis_steps_remaining[1]=0;
       #endif
       #if (Z_MIN_PIN > -1) 
-        if(!move_direction[2]) if(READ(Z_MIN_PIN) != ENDSTOPS_INVERTING) if(primary_axis==2) break; else if(axis_steps_remaining[2]) axis_steps_remaining[2]=0;
+        if(!move_direction[2]) if(READ(Z_MIN_PIN) != Z_ENDSTOP_INVERT) if(primary_axis==2) break; else if(axis_steps_remaining[2]) axis_steps_remaining[2]=0;
       #endif
       #if (Z_MAX_PIN > -1) 
-        if(move_direction[2]) if(READ(Z_MAX_PIN) != ENDSTOPS_INVERTING) if(primary_axis==2) break; else if(axis_steps_remaining[2]) axis_steps_remaining[2]=0;
+        if(move_direction[2]) if(READ(Z_MAX_PIN) != Z_ENDSTOP_INVERT) if(primary_axis==2) break; else if(axis_steps_remaining[2]) axis_steps_remaining[2]=0;
       #endif
       timediff = micros() * 100 - axis_previous_micros[primary_axis];
       if(timediff<0){//check for overflow


### PR DESCRIPTION
This patch was originally made by lemio.

I thought that retrocompatibility should have been preserved by checking whether `ENDSTOPS_INVERTING` was defined, to not break things for users upgrading. However, `ENDSTOPS_INVERTING` is not defined with `#define` but is `const bool`, thus I believe I can't check it using preprocessor directives such as `#ifdef`.

People upgrading will just get compilation errors and will need to update their configuration to use the new `[XYZ]_ENDSTOP_INVERT` options.
