### PR TITLE
PID fixes

### DIFF
--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -118,7 +118,7 @@ char uuid[] = "00000000-0000-0000-0000-000000000000";
 
 //// PID settings:
 // Uncomment the following line to enable PID support. This is untested and could be disastrous. Be careful.
-//#define PIDTEMP
+//#define PIDTEMP 1
 #ifdef PIDTEMP
 #define PID_INTEGRAL_DRIVE_MAX 80 // too big, and heater will lag after changing temperature, too small and it might not compensate enough for long-term errors
 #define PID_PGAIN 1280 //256 is 1.0  // value of 5.0 means that error of 20C is changing it almost halfway of the PWM range
@@ -127,7 +127,7 @@ char uuid[] = "00000000-0000-0000-0000-000000000000";
 // magic formula 1, to get approximate "zero error" PWM duty. It is most likely linear formula
 #define HEATER_DUTY_FOR_SETPOINT(setpoint) (22+1*setpoint)
 // magic formula 2, to make led brightness approximately linear
-#define LED_PWM_FOR_BRIGTHNESS(brightness) ((64*brightness-1384)/(300-brightness))
+#define LED_PWM_FOR_BRIGHTNESS(brightness) ((64*brightness-1384)/(300-brightness))
 #endif
 
 // Change this value (range 1-255) to limit the current to the nozzle

--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -120,10 +120,14 @@ char uuid[] = "00000000-0000-0000-0000-000000000000";
 // Uncomment the following line to enable PID support. This is untested and could be disastrous. Be careful.
 //#define PIDTEMP
 #ifdef PIDTEMP
-#define PID_INTEGRAL_DRIVE_MAX 220
-#define PID_PGAIN 180 //100 is 1.0
-#define PID_IGAIN 2 //100 is 1.0
-#define PID_DGAIN 100 //100 is 1.0
+#define PID_INTEGRAL_DRIVE_MAX 80 // too big, and heater will lag after changing temperature, too small and it might not compensate enough for long-term errors
+#define PID_PGAIN 1280 //256 is 1.0  // value of 5.0 means that error of 20C is changing it almost halfway of the PWM range
+#define PID_IGAIN 64 //256 is 1.0  // value of 0.25 means that each degree error over 1 sec (2 measurements) changes duty cycle by 0.5 units (verify?)
+#define PID_DGAIN 2048 //256 is 1.0  // value of 8.0 means that each degree change over one measurement (half second) adjusts PWM by 8 units to compensate
+// magic formula 1, to get approximate "zero error" PWM duty. It is most likely linear formula
+#define HEATER_DUTY_FOR_SETPOINT(setpoint) (22+1*setpoint)
+// magic formula 2, to make led brightness approximately linear
+#define LED_PWM_FOR_BRIGTHNESS(brightness) ((64*brightness-1384)/(300-brightness))
 #endif
 
 // Change this value (range 1-255) to limit the current to the nozzle

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -1,4 +1,4 @@
-// Tonokip RepRap firmware rewrite based off of Hydra-mmm firmware.
+  // Tonokip RepRap firmware rewrite based off of Hydra-mmm firmware.
 // Licence: GPL
 
 #include "fastio.h"
@@ -112,20 +112,22 @@ char *strchr_pointer; // just a pointer to find chars in the cmd string like X, 
 // degree increments (i.e. 100=25 deg). 
 
 int target_raw = 0;
+int target_temp = 0;
 int current_raw = 0;
 int target_bed_raw = 0;
 int current_bed_raw = 0;
 int tt = 0, bt = 0;
 #ifdef PIDTEMP
   int temp_iState = 0;
-  int temp_dState = 0;
+  int prev_temp = 0;
   int pTerm;
   int iTerm;
   int dTerm;
       //int output;
   int error;
-  int temp_iState_min = 100 * -PID_INTEGRAL_DRIVE_MAX / PID_IGAIN;
-  int temp_iState_max = 100 * PID_INTEGRAL_DRIVE_MAX / PID_IGAIN;
+  int heater_duty = 0;
+  const int temp_iState_min = 256L * -PID_INTEGRAL_DRIVE_MAX / PID_IGAIN;
+  const int temp_iState_max = 256L * PID_INTEGRAL_DRIVE_MAX / PID_IGAIN;
 #endif
 #ifndef HEATER_CURRENT
   #define HEATER_CURRENT 255
@@ -766,7 +768,7 @@ inline void process_commands()
         }
         break;
       case 104: // M104
-        if (code_seen('S')) target_raw = temp2analogh(code_value());
+        if (code_seen('S')) target_raw = temp2analogh(target_temp = code_value());
         #ifdef WATCHPERIOD
             if(target_raw > current_raw){
                 watchmillis = max(1,millis());
@@ -791,6 +793,12 @@ inline void process_commands()
         #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX6675) || defined HEATER_USES_AD595
             Serial.print("ok T:");
             Serial.print(tt); 
+          #ifdef PIDTEMP
+            Serial.print(" @:");
+            Serial.print(heater_duty); 
+            Serial.print(",");
+            Serial.print(iTerm);
+          #endif
           #if TEMP_1_PIN > -1 || defined BED_USES_AD595
             Serial.print(" B:");
             Serial.println(bt); 
@@ -803,7 +811,7 @@ inline void process_commands()
         return;
         //break;
       case 109: { // M109 - Wait for extruder heater to reach target.
-        if (code_seen('S')) target_raw = temp2analogh(code_value());
+        if (code_seen('S')) target_raw = temp2analogh(target_temp = code_value());
         #ifdef WATCHPERIOD
             if(target_raw>current_raw){
                 watchmillis = max(1,millis());
@@ -1461,7 +1469,7 @@ void manage_heater()
   #ifdef WATCHPERIOD
     if(watchmillis && millis() - watchmillis > WATCHPERIOD){
         if(watch_raw + 1 >= current_raw){
-            target_raw = 0;
+            target_temp = target_raw = 0;
             WRITE(HEATER_0_PIN,LOW);
             analogWrite(HEATER_0_PIN, 0);
             #if LED_PIN>-1
@@ -1474,11 +1482,11 @@ void manage_heater()
   #endif
   #ifdef MINTEMP
     if(current_raw <= minttemp)
-        target_raw = 0;
+        target_temp = target_raw = 0;
   #endif
   #ifdef MAXTEMP
     if(current_raw >= maxttemp) {
-        target_raw = 0;
+        target_temp = target_raw = 0;
         #if (ALARM_PIN > -1) 
           WRITE(ALARM_PIN,HIGH);
         #endif
@@ -1486,14 +1494,21 @@ void manage_heater()
   #endif
   #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX6675) || defined (HEATER_USES_AD595)
     #ifdef PIDTEMP
-      error = target_raw - current_raw;
-      pTerm = (PID_PGAIN * error) / 100;
+      int current_temp = analog2temp(current_raw);
+      error = target_temp - current_temp;
+      int delta_temp = current_temp - prev_temp;
+      prev_temp = current_temp;
+      pTerm = ((long)PID_PGAIN * error) / 256;
       temp_iState += error;
       temp_iState = constrain(temp_iState, temp_iState_min, temp_iState_max);
-      iTerm = (PID_IGAIN * temp_iState) / 100;
-      dTerm = (PID_DGAIN * (current_raw - temp_dState)) / 100;
-      temp_dState = current_raw;
-      analogWrite(HEATER_0_PIN, constrain(pTerm + iTerm - dTerm, 0, HEATER_CURRENT));
+      iTerm = ((long)PID_IGAIN * temp_iState) / 256;
+      dTerm = ((long)PID_DGAIN * delta_temp) / 256;
+      const int H0 = min(HEATER_DUTY_FOR_SETPOINT(target_temp),HEATER_CURRENT);
+      heater_duty = H0 + constrain(pTerm + iTerm - dTerm, -H0, HEATER_CURRENT-H0);
+      analogWrite(HEATER_0_PIN, heater_duty);
+      #if LED_PIN>-1
+        analogWrite(LED_PIN, constrain(LED_PWM_FOR_BRIGHTNESS(heater_duty),0,255));
+      #endif
     #else
       if(current_raw >= target_raw)
       {


### PR DESCRIPTION
Fixed some problems with PID algorithm and added some features:
- integer overflow on term calculation multiplication
- error is calculated on degrees instead of raw a2d value, to not remove precision from where it is needed most
- "zero" point of driven value will be based on precalculated linear formula, terms will adjust this zero (to help make integral component actually work with smaller constraint range) - this formula has to be precalculated for particular hotend
- made differential component to relate exponentially based on how close the change was from setpoint value to avoid it interfering with fast heat-up/cooling, yet enabling it to aid to react fast to changes when previous value was close to setpoint.
- output heater PWM duty cycle value (and integral term) in temperature output
- output heater duty cycle with LED indicator (with formula to compensate for brightness/duty cycle curve)
