### PR TITLE
simplified string-to-number conversions

### DIFF
--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -392,7 +392,7 @@ inline void get_command()
   if(strstr(cmdbuffer[bufindw], "N") != NULL)
   {
     strchr_pointer = strchr(cmdbuffer[bufindw], 'N');
-    gcode_N = atoi(strchr_pointer+1);
+    gcode_N = atol(strchr_pointer+1);
     if(gcode_N != gcode_LastN+1 && (strstr(cmdbuffer[bufindw], "M110") == NULL) ) {
       Serial.print("Serial Error: Line Number is not Last Line Number+1, Last Line:");
       Serial.println(gcode_LastN);

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -392,7 +392,7 @@ inline void get_command()
   if(strstr(cmdbuffer[bufindw], "N") != NULL)
   {
     strchr_pointer = strchr(cmdbuffer[bufindw], 'N');
-    gcode_N = (strtol(&cmdbuffer[bufindw][strchr_pointer - cmdbuffer[bufindw] + 1], NULL, 10));
+    gcode_N = atoi(strchr_pointer+1);
     if(gcode_N != gcode_LastN+1 && (strstr(cmdbuffer[bufindw], "M110") == NULL) ) {
       Serial.print("Serial Error: Line Number is not Last Line Number+1, Last Line:");
       Serial.println(gcode_LastN);
@@ -409,7 +409,7 @@ inline void get_command()
       while(cmdbuffer[bufindw][count] != '*') checksum = checksum^cmdbuffer[bufindw][count++];
       strchr_pointer = strchr(cmdbuffer[bufindw], '*');
   
-      if( (int)(strtod(&cmdbuffer[bufindw][strchr_pointer - cmdbuffer[bufindw] + 1], NULL)) != checksum) {
+      if( atoi(strchr_pointer+1) != checksum) {
         Serial.print("Error: checksum mismatch, Last Line:");
         Serial.println(gcode_LastN);
         FlushSerialRequestResend();
@@ -442,7 +442,7 @@ inline void get_command()
   }
 	if((strstr(cmdbuffer[bufindw], "G") != NULL)){
 		strchr_pointer = strchr(cmdbuffer[bufindw], 'G');
-		switch((int)((strtod(&cmdbuffer[bufindw][strchr_pointer - cmdbuffer[bufindw] + 1], NULL)))){
+		switch(atoi(strchr_pointer+1)){
 		case 0:
 		case 1:
               #ifdef SDSUPPORT
@@ -504,8 +504,8 @@ if(!sdmode || serial_count!=0){
 }
 
 
-inline float code_value() { return (strtod(&cmdbuffer[bufindr][strchr_pointer - cmdbuffer[bufindr] + 1], NULL)); }
-inline long code_value_long() { return (strtol(&cmdbuffer[bufindr][strchr_pointer - cmdbuffer[bufindr] + 1], NULL, 10)); }
+inline float code_value() { return strtod(strchr_pointer, NULL); }
+inline long code_value_long() { return atol(strchr_pointer); }
 inline bool code_seen(char code_string[]) { return (strstr(cmdbuffer[bufindr], code_string) != NULL); }  //Return True if the string was found
 
 inline bool code_seen(char code)


### PR DESCRIPTION
I really think that &cmdbuffer[bufindw][strchr_pointer - cmdbuffer[bufindw] + 1] points to strchr_pointer + 1 at all times. And ato[ilf] group of functions is IMO more readable.
