### PR TITLE
Forced oscillation reduction

### DIFF
--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -99,6 +99,12 @@ bool axis_relative_modes[] = {false, false, false, false};
 // If you enable this, make sure STEP_DELAY_MICROS is disabled. (except for Gen6: both need to be enabled.)
 //#define STEP_DELAY_RATIO 0.25
 
+///Oscillation reduction.  Forces x,y,or z axis to be stationary for ## ms before allowing axis to switch direcitons.  Alternative method to prevent skipping steps.  Uncomment the line below to activate.
+//#define RAPID_OSCILLATION_REDUCTION
+#ifdef RAPID_OSCILLATION_REDUCTION
+long min_time_before_dir_change = 30; //milliseconds
+#endif
+
 // Comment this to disable ramp acceleration
 #define RAMP_ACCELERATION
 


### PR DESCRIPTION
This small chunk of code is a brute force method used to force a stop in any axis s.t. axis motors do not instantaneously switch directions and have to overcome the inertia of an imperfectly rigid mass.

Long term such a feature should be encapsulated via the SW slicer and a G4 should be issued to the controller.  However, until then, I have been successfully using this to prevent skipping steps.  It is particularly useful on thin features where an axis will very rapidly oscillate and change directions.

Tested on gen6 h/w.
