### PR TITLE
Stepper enable delay and temperature table

### DIFF
--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -66,6 +66,9 @@ const bool Z_ENDSTOP_INVERT = false;
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0
 
+//Uncomment if you have problems with a stepper driver enabeling too late, this will also set how many microseconds delay there will be after enabeling the driver
+//#define DELAY_ENABLE 15
+
 // Disables axis when it's not being used.
 const bool DISABLE_X = false;
 const bool DISABLE_Y = false;

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -971,7 +971,7 @@ inline void process_commands()
       break;
       case 190: // M190 - Wait bed for heater to reach target.
       #if TEMP_1_PIN > -1
-        if (code_seen('S')) target_bed_raw = temp2analogh(code_value());
+        if (code_seen('S')) target_bed_raw = temp2analogBed(code_value());
         codenum = millis(); 
         while(current_bed_raw < target_bed_raw) {
           if( (millis()-codenum) > 1000 ) //Print Temp Reading every 1 second while heating up.

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -1284,10 +1284,33 @@ inline void linear_move(unsigned long axis_steps_remaining[]) // make linear mov
   //Only enable axis that are moving. If the axis doesn't need to move then it can stay disabled depending on configuration.
   // TODO: maybe it's better to refactor into a generic enable(int axis) function, that will probably take more ram,
   // but will reduce code size
+#ifdef DELAY_ENABLE
+  if(axis_steps_remaining[0])
+  {
+    enable_x();
+    delayMicroseconds(DELAY_ENABLE);
+  }
+  if(axis_steps_remaining[1])
+  {
+    enable_y();
+    delayMicroseconds(DELAY_ENABLE);
+  }
+  if(axis_steps_remaining[2])
+  {
+    enable_z();
+    delayMicroseconds(DELAY_ENABLE);
+  }
+  if(axis_steps_remaining[3])
+  {
+    enable_e();
+    delayMicroseconds(DELAY_ENABLE);
+  }
+#else
   if(axis_steps_remaining[0]) enable_x();
   if(axis_steps_remaining[1]) enable_y();
   if(axis_steps_remaining[2]) enable_z();
   if(axis_steps_remaining[3]) enable_e();
+#endif
 
     //Define variables that are needed for the Bresenham algorithm. Please note that  Z is not currently included in the Bresenham algorithm.
   unsigned long delta[] = {axis_steps_remaining[0], axis_steps_remaining[1], axis_steps_remaining[2], axis_steps_remaining[3]}; //TODO: implement a "for" to support N axes


### PR DESCRIPTION
I had problems with Y not always enabling, adding a short delay after enabling one stepper, fixed the problem with the following not enabling correctly.

Uncomment DELAY_ENABLE to set a 15 microseconds delay after enabling each driver.
