### PR TITLE
Fix communication with standard reprapHost-Software

### DIFF
--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -850,7 +850,7 @@ inline void process_commands()
       #endif
           if( (millis() - codenum) > 1000 ) //Print Temp Reading every 1 second while heating up/cooling down
           {
-            Serial.print("T:");
+            Serial.print("// T:");
             Serial.println( analog2temp(current_raw) );
             codenum = millis();
           }

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -991,7 +991,8 @@ inline void process_commands()
     
   }
   else{
-      Serial.println("Unknown command:");
+      Serial.println("// Unknown command:");
+      Serial.print("// ");
       Serial.println(cmdbuffer[bufindr]);
   }
   

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -938,15 +938,15 @@ inline void process_commands()
         Serial.println(uuid);
         break;
       case 114: // M114
-	Serial.print("X:");
+	Serial.print("ok C: X:");
         Serial.print(current_position[0]);
-	Serial.print("Y:");
+	Serial.print(" Y:");
         Serial.print(current_position[1]);
-	Serial.print("Z:");
+	Serial.print(" Z:");
         Serial.print(current_position[2]);
-	Serial.print("E:");
+	Serial.print(" E:");
         Serial.println(current_position[3]);
-        break;
+        return;
       case 119: // M119
       	#if (X_MIN_PIN > -1)
       	Serial.print("x_min:");

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -938,13 +938,13 @@ inline void process_commands()
         Serial.println(uuid);
         break;
       case 114: // M114
-	Serial.print("ok C: X:");
+        Serial.print("ok C: X:");
         Serial.print(current_position[0]);
-	Serial.print(" Y:");
+        Serial.print(" Y:");
         Serial.print(current_position[1]);
-	Serial.print(" Z:");
+        Serial.print(" Z:");
         Serial.print(current_position[2]);
-	Serial.print(" E:");
+        Serial.print(" E:");
         Serial.println(current_position[3]);
         return;
       case 119: // M119


### PR DESCRIPTION
I'm currently using Sprinter together with the standard reprap host software at [1](version 20111115). There are several modifications required to make this host software communicate with Sprinter.
One problem is, that the host software gets confused with line numbering if several lines are returned as reply (like in the 'unknown command' or temperature reporting case of M109).

According to http://reprap.org/wiki/G-code#Replies_from_the_RepRap_machine_to_the_host_computer
there should be only replies starting with one of 'ok', 'rs', '!!', '//'. So I modified replies not starting with ok to be comments starting with '//' and modified the M114 reply to be consistent with the host software and with the format reported by M105.
Please test those modifications with your host software and merge them into master, if appropriate.

[1] https://github.com/reprap/release 
