### PR TITLE
EEPROM function and small Changes

### DIFF
--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -59,6 +59,24 @@ const bool Z_ENDSTOP_INVERT = false;
 //Only work with Atmega1284 you need +1 kb ram
 //#define SD_FAST_XFER_AKTIV
 
+//-----------------------------------------------------------------------
+//// STORE SETTINGS TO EEPROM
+//-----------------------------------------------------------------------
+// the microcontroller can store settings in the EEPROM
+// M500 - stores paramters in EEPROM
+// M501 - reads parameters from EEPROM (if you need reset them after you changed them temporarily).
+// M502 - reverts to the default "factory settings". You still need to store them in EEPROM afterwards if you want to.
+// M503 - Print settings
+// define this to enable eeprom support
+//#define USE_EEPROM_SETTINGS
+
+// to disable EEPROM Serial responses and decrease program space by ~1000 byte: comment this out:
+// please keep turned on if you can.
+//#define PRINT_EEPROM_SETTING
+
+//-----------------------------------------------------------------------
+//// ARC Function (G2/G3 Command)
+//-----------------------------------------------------------------------
 //Uncomment to aktivate the arc (circle) function (G2/G3 Command)
 //Without SD function an ARC function the used Flash is smaller 31 kb
 #define USE_ARC_FUNCTION

--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -126,7 +126,7 @@ const int Z_MAX_LENGTH = 100;
 //// MOVEMENT SETTINGS
 //-----------------------------------------------------------------------
 const int NUM_AXIS = 4; // The axis order in all axis related arrays is X, Y, Z, E
-#define _MAX_FEEDRATE {400, 400, 4, 45}       // (mm/sec)    
+#define _MAX_FEEDRATE {400, 400, 2, 45}       // (mm/sec)    
 #define _HOMING_FEEDRATE {1500,1500,120}      // (mm/min) !!
 #define _AXIS_RELATIVE_MODES {false, false, false, false}
 

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -39,7 +39,7 @@
   -  move string to flash to free RAM vor forward planner
   -  M203 Temperature monitor for Repetier
 
-  
+ Version 1.3.04T
   - Implement Plannercode from Marlin V1 big thanks to Erik
   - Stepper interrupt with Step loops
   - Stepperfrequenz 30 Khz
@@ -52,6 +52,13 @@
   - Fast Xfer Function --> move Text to Flash
   - Option to deaktivate ARC (G2/G3) function (save flash)
   - Removed modulo (%) operator, which uses an expensive divide
+
+ Version 1.3.05T
+  - changed homing function to not conflict with min_software_endstops/max_software_endstops (thanks rGlory)
+  - Changed check in arc_func
+  - Corrected distance calculation. (thanks jv4779)
+  - MAX Feed Rate for Z-Axis reduced to 2 mm/s some Printers had problems with 4 mm/s
+  
 
 */
 
@@ -142,13 +149,13 @@ void __cxa_pure_virtual(){};
 // M603 - Show Free Ram
 
 
-#define _VERSION_TEXT "1.3.04T / 04.02.2012"
+#define _VERSION_TEXT "1.3.05T / 15.02.2012"
 
 //Stepper Movement Variables
 char axis_codes[NUM_AXIS] = {'X', 'Y', 'Z', 'E'};
-float axis_steps_per_unit[] = _AXIS_STEP_PER_UNIT; 
+float axis_steps_per_unit[4] = _AXIS_STEP_PER_UNIT; 
 
-float max_feedrate[] = _MAX_FEEDRATE;
+float max_feedrate[4] = _MAX_FEEDRATE;
 float homing_feedrate[] = _HOMING_FEEDRATE;
 bool axis_relative_modes[] = _AXIS_RELATIVE_MODES;
 
@@ -157,7 +164,7 @@ float retract_acceleration = _RETRACT_ACCELERATION; // Normal acceleration mm/s^
 float max_xy_jerk = _MAX_XY_JERK;
 float max_z_jerk = _MAX_Z_JERK;
 
-long  max_acceleration_units_per_sq_second[] = _MAX_ACCELERATION_UNITS_PER_SQ_SECOND; // X, Y, Z and E max acceleration in mm/s^2 for printing moves or retracts
+long  max_acceleration_units_per_sq_second[4] = _MAX_ACCELERATION_UNITS_PER_SQ_SECOND; // X, Y, Z and E max acceleration in mm/s^2 for printing moves or retracts
 
 //float max_start_speed_units_per_second[] = _MAX_START_SPEED_UNITS_PER_SECOND;
 //long  max_travel_acceleration_units_per_sq_second[] = _MAX_TRAVEL_ACCELERATION_UNITS_PER_SQ_SECOND; // X, Y, Z max acceleration in mm/s^2 for travel moves
@@ -517,7 +524,7 @@ void setup()
 { 
   
   Serial.begin(BAUDRATE);
-  showString(PSTR("SprinterV2\r\n"));
+  showString(PSTR("Sprinter\r\n"));
   showString(PSTR(_VERSION_TEXT));
   showString(PSTR("\r\n"));
   showString(PSTR("start\r\n"));
@@ -997,20 +1004,22 @@ FORCE_INLINE void process_commands()
           if ((X_MIN_PIN > -1 && X_HOME_DIR==-1) || (X_MAX_PIN > -1 && X_HOME_DIR==1))
           {
             st_synchronize();
-            current_position[X_AXIS] = 0;
+            current_position[X_AXIS] = -1.5 * X_MAX_LENGTH * X_HOME_DIR;
             plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
-            destination[X_AXIS] = 1.5 * X_MAX_LENGTH * X_HOME_DIR;
+            destination[X_AXIS] = 0;
             feedrate = homing_feedrate[X_AXIS];
             prepare_move();
   
             st_synchronize();        
-            current_position[X_AXIS] = 0;
+            current_position[X_AXIS] = 5 * X_HOME_DIR;
             plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
-            destination[X_AXIS] = -5 * X_HOME_DIR;
+            destination[X_AXIS] = 0;
             prepare_move();
   
-            st_synchronize();         
-            destination[X_AXIS] = 10 * X_HOME_DIR;
+            st_synchronize();       
+            current_position[X_AXIS] = -10 * X_HOME_DIR;
+            plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);  
+            destination[X_AXIS] = 0;
             feedrate = homing_feedrate[X_AXIS]/2 ;
             prepare_move();
             st_synchronize();
@@ -1027,20 +1036,22 @@ FORCE_INLINE void process_commands()
         {
           if ((Y_MIN_PIN > -1 && Y_HOME_DIR==-1) || (Y_MAX_PIN > -1 && Y_HOME_DIR==1))
           {
-            current_position[Y_AXIS] = 0;
+            current_position[Y_AXIS] = -1.5 * Y_MAX_LENGTH * Y_HOME_DIR;
             plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
-            destination[Y_AXIS] = 1.5 * Y_MAX_LENGTH * Y_HOME_DIR;
+            destination[Y_AXIS] = 0;
             feedrate = homing_feedrate[Y_AXIS];
             prepare_move();
             st_synchronize();
   
-            current_position[Y_AXIS] = 0;
+            current_position[Y_AXIS] = 5 * Y_HOME_DIR;
             plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
-            destination[Y_AXIS] = -5 * Y_HOME_DIR;
+            destination[Y_AXIS] = 0;
             prepare_move();
             st_synchronize();
   
-            destination[Y_AXIS] = 10 * Y_HOME_DIR;
+            current_position[Y_AXIS] = -10 * Y_HOME_DIR;
+            plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
+            destination[Y_AXIS] = 0;
             feedrate = homing_feedrate[Y_AXIS]/2;
             prepare_move();
             st_synchronize();
@@ -1057,20 +1068,22 @@ FORCE_INLINE void process_commands()
         {
           if ((Z_MIN_PIN > -1 && Z_HOME_DIR==-1) || (Z_MAX_PIN > -1 && Z_HOME_DIR==1))
           {
-            current_position[Z_AXIS] = 0;
+            current_position[Z_AXIS] = -1.5 * Z_MAX_LENGTH * Z_HOME_DIR;
             plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
-            destination[Z_AXIS] = 1.5 * Z_MAX_LENGTH * Z_HOME_DIR;
+            destination[Z_AXIS] = 0;
             feedrate = homing_feedrate[Z_AXIS];
             prepare_move();
             st_synchronize();
   
-            current_position[Z_AXIS] = 0;
+            current_position[Z_AXIS] = 2 * Z_HOME_DIR;
             plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
-            destination[Z_AXIS] = -2 * Z_HOME_DIR;
+            destination[Z_AXIS] = 0;
             prepare_move();
             st_synchronize();
   
-            destination[Z_AXIS] = 3 * Z_HOME_DIR;
+            current_position[Z_AXIS] = -3 * Z_HOME_DIR;
+            plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
+            destination[Z_AXIS] = 0;
             feedrate = homing_feedrate[Z_AXIS]/2;
             prepare_move();
             st_synchronize();
@@ -1470,7 +1483,7 @@ FORCE_INLINE void process_commands()
 //        }
         break;
       case 115: // M115
-        showString(PSTR("FIRMWARE_NAME: SprinterV2 PROTOCOL_VERSION:1.0 MACHINE_TYPE:Mendel EXTRUDER_COUNT:1\r\n"));
+        showString(PSTR("FIRMWARE_NAME: Sprinter Experimental PROTOCOL_VERSION:1.0 MACHINE_TYPE:Mendel EXTRUDER_COUNT:1\r\n"));
         //Serial.println(uuid);
         showString(PSTR(_DEF_CHAR_UUID));
         showString(PSTR("\r\n"));
@@ -2185,8 +2198,13 @@ void plan_buffer_line(float x, float y, float z, float e, float feed_rate)
   delta_mm[Y_AXIS] = (target[Y_AXIS]-position[Y_AXIS])/axis_steps_per_unit[Y_AXIS];
   delta_mm[Z_AXIS] = (target[Z_AXIS]-position[Z_AXIS])/axis_steps_per_unit[Z_AXIS];
   delta_mm[E_AXIS] = (target[E_AXIS]-position[E_AXIS])/axis_steps_per_unit[E_AXIS];
-  block->millimeters = sqrt(square(delta_mm[X_AXIS]) + square(delta_mm[Y_AXIS]) +
-                            square(delta_mm[Z_AXIS]) + square(delta_mm[E_AXIS]));
+  
+  if ( block->steps_x == 0 && block->steps_y == 0 && block->steps_z == 0 ) {
+    block->millimeters = fabs(delta_mm[E_AXIS]);
+  } else {
+    block->millimeters = sqrt(square(delta_mm[X_AXIS]) + square(delta_mm[Y_AXIS]) + square(delta_mm[Z_AXIS]));
+  }
+  
   float inverse_millimeters = 1.0/block->millimeters;  // Inverse millimeters to remove multiple divides 
   
   // Calculate speed in mm/second for each axis. No divide by zero due to previous checks.
@@ -2205,10 +2223,10 @@ void plan_buffer_line(float x, float y, float z, float e, float feed_rate)
     	if(feed_rate<minimumfeedrate) feed_rate=minimumfeedrate;
   } 
 
-#ifdef SLOWDOWN
+
   // slow down when de buffer starts to empty, rather than wait at the corner for a buffer refill
   int moves_queued=(block_buffer_head-block_buffer_tail + BLOCK_BUFFER_SIZE) & (BLOCK_BUFFER_SIZE - 1);
-  
+#ifdef SLOWDOWN  
   if(moves_queued < (BLOCK_BUFFER_SIZE * 0.5) && moves_queued > 1) feed_rate = feed_rate*moves_queued / (BLOCK_BUFFER_SIZE * 0.5); 
 #endif
 
@@ -2326,7 +2344,7 @@ void plan_buffer_line(float x, float y, float z, float e, float feed_rate)
     vmax_junction = max_z_jerk/2;
   vmax_junction = min(vmax_junction, block->nominal_speed);
 
-  if ((block_buffer_head != block_buffer_tail) && (previous_nominal_speed > 0.0)) {
+  if ((moves_queued > 1) && (previous_nominal_speed > 0.0)) {
     float jerk = sqrt(pow((current_speed[X_AXIS]-previous_speed[X_AXIS]), 2)+pow((current_speed[Y_AXIS]-previous_speed[Y_AXIS]), 2));
     if((previous_speed[X_AXIS] != 0.0) || (previous_speed[Y_AXIS] != 0.0)) {
       vmax_junction = block->nominal_speed;

--- a/Sprinter/arc_func.cpp
+++ b/Sprinter/arc_func.cpp
@@ -48,7 +48,7 @@ void mc_arc(float *position, float *target, float *offset, uint8_t axis_0, uint8
   if (isclockwise) { angular_travel -= 2*M_PI; }
   
   float millimeters_of_travel = hypot(angular_travel*radius, fabs(linear_travel));
-  if (millimeters_of_travel == 0.0) { return; }
+  if (millimeters_of_travel < 0.001) { return; }
   uint16_t segments = floor(millimeters_of_travel/MM_PER_ARC_SEGMENT);
   /*  
     // Multiply inverse feed_rate to compensate for the fact that this movement is approximated

--- a/Sprinter/pins.h
+++ b/Sprinter/pins.h
@@ -789,6 +789,62 @@
 
 #endif
 
+/****************************************************************************************
+* Printrboard Rev. B pin assingments (ATMEGA90USB1286)
+* Requires the Teensyduino software with Teensy2.0++ selected in arduino IDE!
+* See http://reprap.org/wiki/Printrboard for more info
+****************************************************************************************/
+#if MOTHERBOARD == 9
+#define MOTHERBOARD 9
+#define KNOWN_BOARD 1
+
+
+#define X_STEP_PIN 0
+#define X_DIR_PIN 1
+#define X_ENABLE_PIN 39
+#define X_MIN_PIN 35
+#define X_MAX_PIN -1
+
+#define Y_STEP_PIN 2
+#define Y_DIR_PIN 3
+#define Y_ENABLE_PIN 38
+#define Y_MIN_PIN 8
+#define Y_MAX_PIN -1
+
+#define Z_STEP_PIN 4
+#define Z_DIR_PIN 5
+#define Z_ENABLE_PIN 23
+#define Z_MIN_PIN 36
+#define Z_MAX_PIN -1
+
+#define E_STEP_PIN 6
+#define E_DIR_PIN 7
+#define E_ENABLE_PIN 19
+
+
+
+#define HEATER_0_PIN 21 // Extruder
+#define HEATER_1_PIN 20 // Bed
+#define FAN_PIN 22 // Fan
+
+#define TEMP_0_PIN 1 // Extruder
+#define TEMP_1_PIN 0 // Bed
+
+#define SDPOWER -1
+#define SDSS 26
+#define LED_PIN -1
+#define PS_ON_PIN -1
+#define KILL_PIN -1
+
+#ifndef SDSUPPORT
+// these pins are defined in the SD library if building with SD support
+#define SCK_PIN 9
+#define MISO_PIN 11
+#define MOSI_PIN 10
+#endif
+
+#endif
+
 #ifndef KNOWN_BOARD
 #error Unknown MOTHERBOARD value in configuration.h
 #endif

--- a/Sprinter/store_eeprom.cpp
+++ b/Sprinter/store_eeprom.cpp
@@ -1,0 +1,213 @@
+/*
+ EEPROM routines to save Sprinter Settings 
+ 
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+*/
+
+#include <avr/eeprom.h>
+#include <avr/pgmspace.h>
+#include <inttypes.h>
+
+#include "sprinter.h"
+#include "store_eeprom.h"
+#include "Configuration.h"
+
+
+
+#ifdef USE_EEPROM_SETTINGS
+
+//======================================================================================
+//========================= Read / Write EEPROM =======================================
+template <class T> int EEPROM_writeAnything(int &ee, const T& value)
+{
+  const byte* p = (const byte*)(const void*)&value;
+  int i;
+  for (i = 0; i < (int)sizeof(value); i++)
+    eeprom_write_byte((unsigned char *)ee++, *p++);
+  return i;
+}
+
+template <class T> int EEPROM_readAnything(int &ee, T& value)
+{
+  byte* p = (byte*)(void*)&value;
+  int i;
+  for (i = 0; i < (int)sizeof(value); i++)
+    *p++ = eeprom_read_byte((unsigned char *)ee++);
+  return i;
+}
+//======================================================================================
+
+
+void EEPROM_StoreSettings() 
+{
+
+  unsigned long ul_help = 20000;
+  unsigned int ui_help = 0;
+  char ver[4]= "000";
+  int i=EEPROM_OFFSET;
+  EEPROM_writeAnything(i,ver); // invalidate data first 
+  EEPROM_writeAnything(i,axis_steps_per_unit);  
+  EEPROM_writeAnything(i,max_feedrate);  
+  EEPROM_writeAnything(i,max_acceleration_units_per_sq_second);
+  EEPROM_writeAnything(i,move_acceleration);
+  EEPROM_writeAnything(i,retract_acceleration);
+  EEPROM_writeAnything(i,minimumfeedrate);
+  EEPROM_writeAnything(i,mintravelfeedrate);
+  EEPROM_writeAnything(i,ul_help);  //Min Segment Time, not used yet
+  EEPROM_writeAnything(i,max_xy_jerk);
+  EEPROM_writeAnything(i,max_z_jerk);
+
+  //PID Settings, not used yet --> placeholder
+  ui_help = 2560;
+  EEPROM_writeAnything(i,ui_help);     //Kp
+  ui_help = 64;
+  EEPROM_writeAnything(i,ui_help);     //Ki
+  ui_help = 4096;
+  EEPROM_writeAnything(i,ui_help);     //Kd
+
+  char ver2[4]=EEPROM_VERSION;
+  i=EEPROM_OFFSET;
+  EEPROM_writeAnything(i,ver2); // validate data
+  showString(PSTR("Settings Stored\r\n"));
+ 
+}
+
+
+void EEPROM_printSettings()
+{  
+      // if def=true, the default values will be used
+  #ifdef PRINT_EEPROM_SETTING
+      showString(PSTR("Steps per unit:\r\n"));
+      showString(PSTR(" M92 X"));
+      Serial.print(axis_steps_per_unit[0]);
+      showString(PSTR(" Y"));
+      Serial.print(axis_steps_per_unit[1]);
+      showString(PSTR(" Z"));
+      Serial.print(axis_steps_per_unit[2]);
+      showString(PSTR(" E"));
+      Serial.println(axis_steps_per_unit[3]);
+      
+      showString(PSTR("Maximum feedrates (mm/s):\r\n"));
+      showString(PSTR("  M203 X"));
+      Serial.print(max_feedrate[0]);
+      showString(PSTR(" Y"));
+      Serial.print(max_feedrate[1]); 
+      showString(PSTR(" Z"));
+      Serial.print(max_feedrate[2]); 
+      showString(PSTR(" E"));
+      Serial.println(max_feedrate[3]);
+
+      showString(PSTR("Maximum Acceleration (mm/s2):\r\n"));
+      showString(PSTR("  M201 X"));
+      Serial.print(max_acceleration_units_per_sq_second[0] ); 
+      showString(PSTR(" Y"));
+      Serial.print(max_acceleration_units_per_sq_second[1] ); 
+      showString(PSTR(" Z"));
+      Serial.print(max_acceleration_units_per_sq_second[2] );
+      showString(PSTR(" E"));
+      Serial.println(max_acceleration_units_per_sq_second[3]);
+
+      showString(PSTR("Acceleration: S=acceleration, T=retract acceleration\r\n"));
+      showString(PSTR("  M204 S"));
+      Serial.print(move_acceleration ); 
+      showString(PSTR(" T"));
+      Serial.println(retract_acceleration);
+
+      showString(PSTR("Advanced variables: S=Min feedrate (mm/s), T=Min travel feedrate (mm/s), X=maximum xY jerk (mm/s),  Z=maximum Z jerk (mm/s)\r\n"));
+
+      showString(PSTR("  M205 S"));
+      Serial.print(minimumfeedrate ); 
+      showString(PSTR(" T" ));
+      Serial.print(mintravelfeedrate ); 
+//      showString(PSTR(" B"));
+//      Serial.print(minsegmenttime ); 
+      showString(PSTR(" X"));
+      Serial.print(max_xy_jerk ); 
+      showString(PSTR(" Z"));
+      Serial.println(max_z_jerk);
+      
+    #ifdef PIDTEMP
+    /*
+      showString(PSTR("PID settings:");
+      showString(PSTR("   M301 P"));
+      Serial.print(Kp); 
+      showString(PSTR(" I"));
+      Serial.print(Ki); 
+      SshowString(PSTR(" D"));
+      Serial.print(Kd);
+    */
+    #endif
+  #endif
+
+} 
+
+
+void EEPROM_RetrieveSettings(bool def, bool printout)
+{  // if def=true, the default values will be used
+
+    int i=EEPROM_OFFSET;
+    char stored_ver[4];
+    char ver[4]=EEPROM_VERSION;
+    unsigned long ul_help = 0;
+    
+    EEPROM_readAnything(i,stored_ver); //read stored version
+    if ((!def)&&(strncmp(ver,stored_ver,3)==0)) 
+    {   // version number match
+      EEPROM_readAnything(i,axis_steps_per_unit);  
+      EEPROM_readAnything(i,max_feedrate);  
+      EEPROM_readAnything(i,max_acceleration_units_per_sq_second);
+      EEPROM_readAnything(i,move_acceleration);
+      EEPROM_readAnything(i,retract_acceleration);
+      EEPROM_readAnything(i,minimumfeedrate);
+      EEPROM_readAnything(i,mintravelfeedrate);
+      EEPROM_readAnything(i,ul_help);  //min Segmenttime --> not used yet
+      EEPROM_readAnything(i,max_xy_jerk);
+      EEPROM_readAnything(i,max_z_jerk);
+
+      unsigned int Kp,Ki,Kd;
+      EEPROM_readAnything(i,Kp);
+      EEPROM_readAnything(i,Ki);
+      EEPROM_readAnything(i,Kd);
+
+      showString(PSTR("Stored settings retreived\r\n"));
+    }
+    else 
+    {
+
+      float tmp1[]=_AXIS_STEP_PER_UNIT;
+      float tmp2[]=_MAX_FEEDRATE;
+      long tmp3[]=_MAX_ACCELERATION_UNITS_PER_SQ_SECOND;
+      for (short i=0;i<4;i++) 
+      {
+        axis_steps_per_unit[i]=tmp1[i];  
+        max_feedrate[i]=tmp2[i];  
+        max_acceleration_units_per_sq_second[i]=tmp3[i];
+      }
+      move_acceleration=_ACCELERATION;
+      retract_acceleration=_RETRACT_ACCELERATION;
+      minimumfeedrate=DEFAULT_MINIMUMFEEDRATE;
+      mintravelfeedrate=DEFAULT_MINTRAVELFEEDRATE;
+      max_xy_jerk=_MAX_XY_JERK;
+      max_z_jerk=_MAX_Z_JERK;
+
+      showString(PSTR("Using Default settings\r\n"));
+    }
+
+    if(printout)
+    {
+      EEPROM_printSettings();
+    }
+}  
+
+#endif

--- a/Sprinter/store_eeprom.h
+++ b/Sprinter/store_eeprom.h
@@ -1,0 +1,49 @@
+/*
+ EEPROM routines to save Sprinter Settings 
+ 
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+*/
+
+
+#ifndef __EEPROMH
+#define __EEPROMH
+
+#define EEPROM_OFFSET 100
+
+
+// IMPORTANT:  Whenever there are changes made to the variables stored in EEPROM
+// in the functions below, also increment the version number. This makes sure that
+// the default values are used whenever there is a change to the data, to prevent
+// wrong data being written to the variables.
+// ALSO:  always make sure the variables in the Store and retrieve sections are in the same order.
+#define EEPROM_VERSION "S01"  
+
+
+extern float axis_steps_per_unit[4]; 
+extern float max_feedrate[4];
+extern long  max_acceleration_units_per_sq_second[4];
+extern float move_acceleration;
+extern float retract_acceleration;
+extern float mintravelfeedrate;
+extern float minimumfeedrate;
+extern float max_xy_jerk;
+extern float max_z_jerk;
+
+
+extern void EEPROM_RetrieveSettings(bool def, bool printout );
+extern void EEPROM_printSettings();
+extern void EEPROM_StoreSettings();
+
+
+#endif


### PR DESCRIPTION
- Changed homing function to not conflict with min_software_endstops/max_software_endstops
- Changed check in arc_func
- Corrected distance calculation.
- MAX Feed Rate for Z-Axis reduced to 2 mm/s some Printers had problems with 4 mm/s
  - the microcontroller can store settings in the EEPROM
  - M500 - stores paramters in EEPROM
  - M501 - reads parameters from EEPROM 
  - M502 - reverts to the default "factory settings".
  - M503 - Print settings
