### PR TITLE
Fix Makefile in experimental

### DIFF
--- a/Sprinter/Makefile
+++ b/Sprinter/Makefile
@@ -55,7 +55,7 @@ $(ARDUINO)/wiring_analog.c $(ARDUINO)/wiring_digital.c \
 $(ARDUINO)/wiring_pulse.c \
 $(ARDUINO)/wiring_shift.c $(ARDUINO)/WInterrupts.c
 CXXSRC = $(ARDUINO)/HardwareSerial.cpp $(ARDUINO)/WMath.cpp $(ARDUINO)/WString.cpp\
-$(ARDUINO)/Print.cpp ./SdFile.cpp ./SdVolume.cpp ./Sd2Card.cpp
+$(ARDUINO)/Print.cpp ./SdFile.cpp ./SdVolume.cpp ./Sd2Card.cpp ./heater.cpp ./arc_func.cpp
 FORMAT = ihex
 
 

--- a/Sprinter/Sprinter.h
+++ b/Sprinter/Sprinter.h
@@ -95,10 +95,14 @@ void showString (PGM_P s);
 
 void manage_inactivity(byte debug);
 
-
+void get_command();
 void get_coordinates();
 void prepare_move();
 void prepare_arc_move(char isclockwise);
+FORCE_INLINE void process_commands();
+#ifdef USE_ARC_FUNCTION
+  FORCE_INLINE void get_arc_coordinates();
+#endif
 
 void kill(byte debug);
 
@@ -110,9 +114,13 @@ void plan_buffer_line(float x, float y, float z, float e, float feed_rate);
 void plan_set_position(float x, float y, float z, float e);
 void st_wake_up();
 void st_synchronize();
+void st_set_position(const long &x, const long &y, const long &z, const long &e);
 
 void check_buffer_while_arc();
 
+#ifdef SDSUPPORT
+void print_disk_info(void);
+#endif //SDSUPPORT
 
 #ifdef DEBUG
 void log_message(char*   message);


### PR DESCRIPTION
To compile Sprinter experimental using the Makefile:
- add forward declarations in Sprinter.h
- add new files heater.cpp and arc_func.cpp to Makefile
