### PR TITLE
Compile fails if SD_FAST_XFER_AKTIV is on and PID is off

### DIFF
--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -359,7 +359,7 @@ unsigned char manage_monitor = 255;
   #ifdef SD_FAST_XFER_AKTIV
   
   #ifdef PIDTEMP
-    extern int g_heater_pwm_val;
+    extern volatile unsigned char g_heater_pwm_val;
   #endif
   
   void fast_xfer()
@@ -371,7 +371,9 @@ unsigned char manage_monitor = 255;
     if(HEATER_0_PIN > -1) WRITE(HEATER_0_PIN,LOW);
     if(HEATER_1_PIN > -1) WRITE(HEATER_1_PIN,LOW);
     
+  #ifdef PIDTEMP
     g_heater_pwm_val = 0;
+  #endif
     
     lastxferchar = 1;
     xferbytes = 0;


### PR DESCRIPTION
Bug: turn on SD_FAST_XFER_AKTIV and compilation fails if PID is disabled.

Fix:
If SD_FAST_XFER_AKTIV is defined, fast_xfer() only declares g_heater_pwm_val if PIDTEMP is defined, but later assigns g_heater_pwm_val=0 regardless whether PIDTEMP is defined or not. If PIDTEMP is undefined, g_heater_pwm_val is undeclared at compile time and generates the appropriate error. I solved by not using g_heater_pwm_val if PIDTEMP is undefined (and therefor undeclared.)

Also, the extern declaration was as an int, when g_heater_pwm_val is defined as a volatile unsigned char. This caused a duplicate declaration error, which was solved by changing the declaration in fast_xfer() to
match the definition. I didn't dig deeper to try to understand if the mismatch was intentional or test operation other than verify the compile errors no longer occur.
