### PR TITLE
additional dropsegments test

### DIFF
--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -2348,7 +2348,7 @@ void plan_buffer_line(float x, float y, float z, float e, float feed_rate)
   delta_mm[Z_AXIS] = (target[Z_AXIS]-position[Z_AXIS])/axis_steps_per_unit[Z_AXIS];
   delta_mm[E_AXIS] = (target[E_AXIS]-position[E_AXIS])/axis_steps_per_unit[E_AXIS];
   
-  if ( block->steps_x == 0 && block->steps_y == 0 && block->steps_z == 0 ) {
+  if ( block->steps_x <= dropsegments && block->steps_y <= dropsegments && block->steps_z <= dropsegments ) {
     block->millimeters = fabs(delta_mm[E_AXIS]);
   } else {
     block->millimeters = sqrt(square(delta_mm[X_AXIS]) + square(delta_mm[Y_AXIS]) + square(delta_mm[Z_AXIS]));


### PR DESCRIPTION
If a small move is drop and the next move is retract the speed is wrong calculated

see https://github.com/kliment/Sprinter/issues/170
thanks to jschleic
