### PR TITLE
Refactor eeprom routines

### DIFF
--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -199,6 +199,11 @@ const long min_time_before_dir_change = 30; //milliseconds
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+#define _MIN_SEG_TIME 20000
+#define DEFAULT_KP 2560
+#define DEFAULT_KI 64
+#define DEFAULT_KD 4096
+
 // If defined the movements slow down when the look ahead buffer is only half full
 #define SLOWDOWN
 

--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -200,9 +200,6 @@ const long min_time_before_dir_change = 30; //milliseconds
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
 #define _MIN_SEG_TIME 20000
-#define DEFAULT_KP 2560
-#define DEFAULT_KI 64
-#define DEFAULT_KD 4096
 
 // If defined the movements slow down when the look ahead buffer is only half full
 #define SLOWDOWN

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -1103,9 +1103,9 @@ FORCE_INLINE bool code_seen(char code)
   return (strchr_pointer != NULL);  //Return True if a character was found
 }
 
-FORCE_INLINE void homing_routine(char axis)
+FORCE_INLINE int homing_routine(char axis)
 {
-  int min_pin, max_pin, home_dir, max_length, home_bounce;
+  int min_pin, max_pin, home_dir, max_length, home_bounce, distance=0;
 
   switch(axis){
     case X_AXIS:
@@ -1143,11 +1143,15 @@ FORCE_INLINE void homing_routine(char axis)
     prepare_move();
     st_synchronize();
 
+    distance = current_position[axis] + 1.5 * max_length * home_dir;
+
     current_position[axis] = home_bounce/2 * home_dir;
     plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
     destination[axis] = 0;
     prepare_move();
     st_synchronize();
+
+    distance -= home_bounce/2 * home_dir;
 
     current_position[axis] = -home_bounce * home_dir;
     plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
@@ -1156,12 +1160,15 @@ FORCE_INLINE void homing_routine(char axis)
     prepare_move();
     st_synchronize();
 
+    distance += current_position[axis] + home_bounce * home_dir;
+
     current_position[axis] = (home_dir == -1) ? 0 : max_length;
     current_position[axis] += add_homing[axis];
     plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
     destination[axis] = current_position[axis];
     feedrate = 0;
   }
+  return distance; //distance traveled while homing the given axis
 }
 
 //------------------------------------------------

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -250,7 +250,7 @@ float max_xy_jerk = _MAX_XY_JERK;
 float max_z_jerk = _MAX_Z_JERK;
 float max_e_jerk = _MAX_E_JERK;
 unsigned long min_seg_time = _MIN_SEG_TIME;
-unsigned int Kp = DEFAULT_KP, Ki = DEFAULT_KI, Kd = DEFAULT_KD;
+unsigned int Kp = PID_PGAIN, Ki = PID_IGAIN, Kd = PID_DGAIN;
 
 long  max_acceleration_units_per_sq_second[4] = _MAX_ACCELERATION_UNITS_PER_SQ_SECOND; // X, Y, Z and E max acceleration in mm/s^2 for printing moves or retracts
 

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -249,6 +249,8 @@ float retract_acceleration = _RETRACT_ACCELERATION; // Normal acceleration mm/s^
 float max_xy_jerk = _MAX_XY_JERK;
 float max_z_jerk = _MAX_Z_JERK;
 float max_e_jerk = _MAX_E_JERK;
+unsigned long min_seg_time = _MIN_SEG_TIME;
+unsigned int Kp = DEFAULT_KP, Ki = DEFAULT_KI, Kd = DEFAULT_KD;
 
 long  max_acceleration_units_per_sq_second[4] = _MAX_ACCELERATION_UNITS_PER_SQ_SECOND; // X, Y, Z and E max acceleration in mm/s^2 for printing moves or retracts
 

--- a/Sprinter/store_eeprom.cpp
+++ b/Sprinter/store_eeprom.cpp
@@ -29,21 +29,21 @@
 
 //======================================================================================
 //========================= Read / Write EEPROM =======================================
-template <class T> int EEPROM_writeAnything(int &ee, const T& value)
+template <class T> int EEPROM_write_setting(int address, const T& value)
 {
   const byte* p = (const byte*)(const void*)&value;
   int i;
   for (i = 0; i < (int)sizeof(value); i++)
-    eeprom_write_byte((unsigned char *)ee++, *p++);
+    eeprom_write_byte((unsigned char *)address++, *p++);
   return i;
 }
 
-template <class T> int EEPROM_readAnything(int &ee, T& value)
+template <class T> int EEPROM_read_setting(int address, T& value)
 {
   byte* p = (byte*)(void*)&value;
   int i;
   for (i = 0; i < (int)sizeof(value); i++)
-    *p++ = eeprom_read_byte((unsigned char *)ee++);
+    *p++ = eeprom_read_byte((unsigned char *)address++);
   return i;
 }
 //======================================================================================
@@ -51,35 +51,27 @@ template <class T> int EEPROM_readAnything(int &ee, T& value)
 
 void EEPROM_StoreSettings() 
 {
-
-  unsigned long ul_help = 20000;
-  unsigned int ui_help = 0;
   char ver[4]= "000";
-  int i=EEPROM_OFFSET;
-  EEPROM_writeAnything(i,ver); // invalidate data first 
-  EEPROM_writeAnything(i,axis_steps_per_unit);  
-  EEPROM_writeAnything(i,max_feedrate);  
-  EEPROM_writeAnything(i,max_acceleration_units_per_sq_second);
-  EEPROM_writeAnything(i,move_acceleration);
-  EEPROM_writeAnything(i,retract_acceleration);
-  EEPROM_writeAnything(i,minimumfeedrate);
-  EEPROM_writeAnything(i,mintravelfeedrate);
-  EEPROM_writeAnything(i,ul_help);  //Min Segment Time, not used yet
-  EEPROM_writeAnything(i,max_xy_jerk);
-  EEPROM_writeAnything(i,max_z_jerk);
-  EEPROM_writeAnything(i,max_e_jerk);
+  EEPROM_write_setting(EEPROM_OFFSET, ver); // invalidate data first
+  EEPROM_write_setting(axis_steps_per_unit_address, axis_steps_per_unit);
+  EEPROM_write_setting(max_feedrate_address, max_feedrate);
+  EEPROM_write_setting(max_acceleration_units_per_sq_second_address, max_acceleration_units_per_sq_second);
+  EEPROM_write_setting(move_acceleration_address, move_acceleration);
+  EEPROM_write_setting(retract_acceleration_address, retract_acceleration);
+  EEPROM_write_setting(minimumfeedrate_address, minimumfeedrate);
+  EEPROM_write_setting(mintravelfeedrate_address, mintravelfeedrate);
+  EEPROM_write_setting(min_seg_time_address, min_seg_time);  //Min Segment Time, not used yet
+  EEPROM_write_setting(max_xy_jerk_address, max_xy_jerk);
+  EEPROM_write_setting(max_z_jerk_address, max_z_jerk);
+  EEPROM_write_setting(max_e_jerk_address, max_e_jerk);
 
   //PID Settings, not used yet --> placeholder
-  ui_help = 2560;
-  EEPROM_writeAnything(i,ui_help);     //Kp
-  ui_help = 64;
-  EEPROM_writeAnything(i,ui_help);     //Ki
-  ui_help = 4096;
-  EEPROM_writeAnything(i,ui_help);     //Kd
+  EEPROM_write_setting(Kp_address, Kp);     //Kp
+  EEPROM_write_setting(Ki_address, Ki);     //Ki
+  EEPROM_write_setting(Kd_address, Kd);     //Kd
 
   char ver2[4]=EEPROM_VERSION;
-  i=EEPROM_OFFSET;
-  EEPROM_writeAnything(i,ver2); // validate data
+  EEPROM_write_setting(EEPROM_OFFSET, ver2); // validate data
   showString(PSTR("Settings Stored\r\n"));
  
 }
@@ -87,7 +79,6 @@ void EEPROM_StoreSettings()
 
 void EEPROM_printSettings()
 {  
-      // if def=true, the default values will be used
   #ifdef PRINT_EEPROM_SETTING
       showString(PSTR("Steps per unit:\r\n"));
       showString(PSTR(" M92 X"));
@@ -163,27 +154,24 @@ void EEPROM_RetrieveSettings(bool def, bool printout)
     int i=EEPROM_OFFSET;
     char stored_ver[4];
     char ver[4]=EEPROM_VERSION;
-    unsigned long ul_help = 0;
     
-    EEPROM_readAnything(i,stored_ver); //read stored version
-    if ((!def)&&(strncmp(ver,stored_ver,3)==0)) 
+    EEPROM_read_setting(EEPROM_OFFSET,stored_ver); //read stored version
+    if ((!def)&&(strncmp(ver,stored_ver,3)==0))
     {   // version number match
-      EEPROM_readAnything(i,axis_steps_per_unit);  
-      EEPROM_readAnything(i,max_feedrate);  
-      EEPROM_readAnything(i,max_acceleration_units_per_sq_second);
-      EEPROM_readAnything(i,move_acceleration);
-      EEPROM_readAnything(i,retract_acceleration);
-      EEPROM_readAnything(i,minimumfeedrate);
-      EEPROM_readAnything(i,mintravelfeedrate);
-      EEPROM_readAnything(i,ul_help);  //min Segmenttime --> not used yet
-      EEPROM_readAnything(i,max_xy_jerk);
-      EEPROM_readAnything(i,max_z_jerk);
-      EEPROM_readAnything(i,max_e_jerk);
-
-      unsigned int Kp,Ki,Kd;
-      EEPROM_readAnything(i,Kp);
-      EEPROM_readAnything(i,Ki);
-      EEPROM_readAnything(i,Kd);
+      EEPROM_read_setting(axis_steps_per_unit_address, axis_steps_per_unit);
+      EEPROM_read_setting(max_feedrate_address, max_feedrate);
+      EEPROM_read_setting(max_acceleration_units_per_sq_second_address, max_acceleration_units_per_sq_second);
+      EEPROM_read_setting(move_acceleration_address, move_acceleration);
+      EEPROM_read_setting(retract_acceleration_address, retract_acceleration);
+      EEPROM_read_setting(minimumfeedrate_address, minimumfeedrate);
+      EEPROM_read_setting(mintravelfeedrate_address, mintravelfeedrate);
+      EEPROM_read_setting(min_seg_time_address, min_seg_time);  //min Segmenttime --> not used yet
+      EEPROM_read_setting(max_xy_jerk_address, max_xy_jerk);
+      EEPROM_read_setting(max_z_jerk_address, max_z_jerk);
+      EEPROM_read_setting(max_e_jerk_address, max_e_jerk);
+      EEPROM_read_setting(Kp_address, Kp);
+      EEPROM_read_setting(Ki_address, Ki);
+      EEPROM_read_setting(Kd_address, Kd);
 
       showString(PSTR("Stored settings retreived\r\n"));
     }
@@ -206,6 +194,10 @@ void EEPROM_RetrieveSettings(bool def, bool printout)
       max_xy_jerk=_MAX_XY_JERK;
       max_z_jerk=_MAX_Z_JERK;
       max_e_jerk=_MAX_E_JERK;
+      min_seg_time=_MIN_SEG_TIME;
+      Kp = DEFAULT_KP;
+      Ki = DEFAULT_KI;
+      Kd = DEFAULT_KD;
 
       showString(PSTR("Using Default settings\r\n"));
     }

--- a/Sprinter/store_eeprom.cpp
+++ b/Sprinter/store_eeprom.cpp
@@ -195,9 +195,9 @@ void EEPROM_RetrieveSettings(bool def, bool printout)
       max_z_jerk=_MAX_Z_JERK;
       max_e_jerk=_MAX_E_JERK;
       min_seg_time=_MIN_SEG_TIME;
-      Kp = DEFAULT_KP;
-      Ki = DEFAULT_KI;
-      Kd = DEFAULT_KD;
+      Kp = PID_PGAIN;
+      Ki = PID_IGAIN;
+      Kd = PID_DGAIN;
 
       showString(PSTR("Using Default settings\r\n"));
     }

--- a/Sprinter/store_eeprom.h
+++ b/Sprinter/store_eeprom.h
@@ -27,7 +27,7 @@
 // the default values are used whenever there is a change to the data, to prevent
 // wrong data being written to the variables.
 // ALSO:  always make sure the variables in the Store and retrieve sections are in the same order.
-#define EEPROM_VERSION "S02"  
+#define EEPROM_VERSION "S03"
 
 
 extern float axis_steps_per_unit[4]; 
@@ -40,7 +40,23 @@ extern float minimumfeedrate;
 extern float max_xy_jerk;
 extern float max_z_jerk;
 extern float max_e_jerk;
+extern unsigned long min_seg_time;
+extern unsigned int Kp, Ki, Kd;
 
+#define axis_steps_per_unit_address                     (EEPROM_OFFSET +  4)
+#define max_feedrate_address                            (EEPROM_OFFSET + 20)
+#define max_acceleration_units_per_sq_second_address    (EEPROM_OFFSET + 36)
+#define move_acceleration_address                       (EEPROM_OFFSET + 52)
+#define retract_acceleration_address                    (EEPROM_OFFSET + 56)
+#define mintravelfeedrate_address                       (EEPROM_OFFSET + 60)
+#define minimumfeedrate_address                         (EEPROM_OFFSET + 64)
+#define max_xy_jerk_address                             (EEPROM_OFFSET + 68)
+#define max_z_jerk_address                              (EEPROM_OFFSET + 72)
+#define max_e_jerk_address                              (EEPROM_OFFSET + 76)
+#define min_seg_time_address                            (EEPROM_OFFSET + 80)
+#define Kp_address                                      (EEPROM_OFFSET + 84)
+#define Ki_address                                      (EEPROM_OFFSET + 86)
+#define Kd_address                                      (EEPROM_OFFSET + 88)
 
 extern void EEPROM_RetrieveSettings(bool def, bool printout );
 extern void EEPROM_printSettings();

--- a/Sprinter/store_eeprom.h
+++ b/Sprinter/store_eeprom.h
@@ -43,20 +43,20 @@ extern float max_e_jerk;
 extern unsigned long min_seg_time;
 extern unsigned int Kp, Ki, Kd;
 
-#define axis_steps_per_unit_address                     (EEPROM_OFFSET +  4)
-#define max_feedrate_address                            (EEPROM_OFFSET + 20)
-#define max_acceleration_units_per_sq_second_address    (EEPROM_OFFSET + 36)
-#define move_acceleration_address                       (EEPROM_OFFSET + 52)
-#define retract_acceleration_address                    (EEPROM_OFFSET + 56)
-#define mintravelfeedrate_address                       (EEPROM_OFFSET + 60)
-#define minimumfeedrate_address                         (EEPROM_OFFSET + 64)
-#define max_xy_jerk_address                             (EEPROM_OFFSET + 68)
-#define max_z_jerk_address                              (EEPROM_OFFSET + 72)
-#define max_e_jerk_address                              (EEPROM_OFFSET + 76)
-#define min_seg_time_address                            (EEPROM_OFFSET + 80)
-#define Kp_address                                      (EEPROM_OFFSET + 84)
-#define Ki_address                                      (EEPROM_OFFSET + 86)
-#define Kd_address                                      (EEPROM_OFFSET + 88)
+#define axis_steps_per_unit_address (EEPROM_OFFSET + 4*sizeof(char))
+#define max_feedrate_address (axis_steps_per_unit_address + 4*sizeof(float))
+#define max_acceleration_units_per_sq_second_address (max_feedrate_address + 4*sizeof(float))
+#define move_acceleration_address (max_acceleration_units_per_sq_second_address + 4*sizeof(long))
+#define retract_acceleration_address (move_acceleration_address + sizeof(float))
+#define mintravelfeedrate_address (retract_acceleration_address + sizeof(float))
+#define minimumfeedrate_address (mintravelfeedrate_address + sizeof(float))
+#define max_xy_jerk_address (minimumfeedrate_address + sizeof(float))
+#define max_z_jerk_address (max_xy_jerk_address + sizeof(float))
+#define max_e_jerk_address (max_z_jerk_address + sizeof(float))
+#define min_seg_time_address (max_e_jerk_address + sizeof(float))
+#define Kp_address (min_seg_time_address + sizeof(unsigned long))
+#define Ki_address (Kp_address + sizeof(unsigned int))
+#define Kd_address (Ki_address + sizeof(unsigned int))
 
 extern void EEPROM_RetrieveSettings(bool def, bool printout );
 extern void EEPROM_printSettings();


### PR DESCRIPTION
This pull request contains 2 unrelated commits. I'm not sure how to split it in two pull requests.

One of the commits refactors the eeprom routines so that it is now possible to modify the value of a single parameter stored in eeprom without having to save all the other variable values also. This will be useful for storing the z_max_length value, as part of the software-callibration routines I'm working on for the z-axis.

The other commit modifies the homing routine so that it reports how far did it travel while homing. It will also be useful for the z-axis software-calibration routine.
