### PR TITLE
Fixes an array length calculation bug that breaks M42 pin setting.

### DIFF
--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -1389,7 +1389,7 @@ FORCE_INLINE void process_commands()
           if (code_seen('P') && pin_status >= 0 && pin_status <= 255)
           {
             int pin_number = code_value();
-            for(int i = 0; i < sizeof(sensitive_pins); i++)
+            for(int i = 0; i < sizeof(sensitive_pins) / sizeof(int); i++)
             {
               if (sensitive_pins[i] == pin_number)
               {


### PR DESCRIPTION
From Jason von Nieda, as discussed in IRC.
