### PR TITLE
check temperatures more often during PID autotune

### DIFF
--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -312,7 +312,7 @@ const int dropsegments=5; //everything with less than this number of steps will 
 #define HEATER_CURRENT 255
 
 // How often should the heater check for new temp readings, in milliseconds
-#define HEATER_CHECK_INTERVAL 500
+#define HEATER_CHECK_INTERVAL 100
 #define BED_CHECK_INTERVAL 5000
 
 // Comment the following line to enable heat management during acceleration

--- a/Sprinter/heater.cpp
+++ b/Sprinter/heater.cpp
@@ -466,7 +466,7 @@ void PID_autotune(int PIDAT_test_temp)
       #endif  
     }
     
-    if(PIDAT_input > (PIDAT_test_temp + 25)) 
+    if(PIDAT_input > (PIDAT_test_temp + 55)) 
     {
       showString(PSTR("PID Autotune failed! Temperature to high\r\n"));
       return;


### PR DESCRIPTION
also tolerate 55c overshoot- default temp is 150c, 205 is not dangerous for hotends
