### PR TITLE
Added support for MAX31855/MAX6675 on Sanguinololu

### DIFF
--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -354,10 +354,13 @@ const int dropsegments=5; //everything with less than this number of steps will 
 #define HEATER_USES_THERMISTOR
 //#define HEATER_USES_AD595
 //#define HEATER_USES_MAX6675
+//#define HEATER_USES_MAX31855
 
 // Select one of these only to define how the bed temp is read.
 #define BED_USES_THERMISTOR
 //#define BED_USES_AD595
+//#define HEATER_USES_MAX6675
+//#define HEATER_USES_MAX31855
 
 //This is for controlling a fan to cool down the stepper drivers
 //it will turn on when any driver is enabled

--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -20,6 +20,7 @@
 #define MOTHERBOARD 33
 
 //// Thermistor settings:
+// -1 is thermocouple
 // 1 is 100k thermistor
 // 2 is 200k thermistor
 // 3 is mendel-parts thermistor

--- a/Sprinter/Configuration.h
+++ b/Sprinter/Configuration.h
@@ -359,8 +359,8 @@ const int dropsegments=5; //everything with less than this number of steps will 
 // Select one of these only to define how the bed temp is read.
 #define BED_USES_THERMISTOR
 //#define BED_USES_AD595
-//#define HEATER_USES_MAX6675
-//#define HEATER_USES_MAX31855
+//#define BED_USES_MAX6675
+//#define BED_USES_MAX31855
 
 //This is for controlling a fan to cool down the stepper drivers
 //it will turn on when any driver is enabled

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -396,7 +396,7 @@ unsigned char manage_monitor = 255;
   void initsd()
   {
   sdactive = false;
-  #if SDSS >- 1
+  #if SDSS > -1
     if(root.isOpen())
         root.close();
 
@@ -837,6 +837,8 @@ void setup()
   
   SET_OUTPUT(MAX6675_SS);
   WRITE(MAX6675_SS,1);
+  
+  SET_OUTPUT(SPI_SS);
 #endif  
 
 #ifdef HEATER_USES_MAX31855
@@ -851,6 +853,8 @@ void setup()
   
   SET_OUTPUT(MAX31855_SS);
   WRITE(MAX31855_SS,1);
+  
+  SET_OUTPUT(SPI_SS);
 #endif  
  
 #ifdef SDSUPPORT
@@ -1502,7 +1506,7 @@ FORCE_INLINE void process_commands()
 #ifdef CHAIN_OF_COMMAND
           st_synchronize(); // wait for all movements to finish
 #endif
-        #if TEMP_1_PIN > -1 || defined BED_USES_AD595
+        #if TEMP_1_PIN > -1 || defined (BED_USES_MAX31855)|| defined (BED_USES_MAX6675)|| defined BED_USES_AD595
             if (code_seen('S')) target_bed_raw = temp2analogBed(code_value());
         #endif
         break;
@@ -1510,7 +1514,7 @@ FORCE_INLINE void process_commands()
         #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX31855)|| defined (HEATER_USES_MAX6675)|| defined HEATER_USES_AD595
           hotendtC = analog2temp(current_raw);
         #endif
-        #if TEMP_1_PIN > -1 || defined BED_USES_AD595
+        #if TEMP_1_PIN > -1 || defined (BED_USES_MAX31855)|| defined (BED_USES_MAX6675)|| defined BED_USES_AD595
           bedtempC = analog2tempBed(current_bed_raw);
         #endif
         #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX31855) || defined (HEATER_USES_MAX6675) || defined HEATER_USES_AD595
@@ -1532,7 +1536,7 @@ FORCE_INLINE void process_commands()
               Serial.print(autotemp_setpoint);
             #endif
           #endif
-          #if TEMP_1_PIN > -1 || defined BED_USES_AD595
+          #if TEMP_1_PIN > -1 || defined (BED_USES_MAX31855)|| defined (BED_USES_MAX6675)|| defined BED_USES_AD595
             showString(PSTR(" B:"));
             Serial.println(bedtempC); 
           #else

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -838,6 +838,20 @@ void setup()
   SET_OUTPUT(MAX6675_SS);
   WRITE(MAX6675_SS,1);
 #endif  
+
+#ifdef HEATER_USES_MAX31855
+  SET_OUTPUT(SCK_PIN);
+  WRITE(SCK_PIN,0);
+  
+  SET_OUTPUT(MOSI_PIN);
+  WRITE(MOSI_PIN,1);
+  
+  SET_INPUT(MISO_PIN);
+  WRITE(MISO_PIN,1);
+  
+  SET_OUTPUT(MAX31855_SS);
+  WRITE(MAX31855_SS,1);
+#endif  
  
 #ifdef SDSUPPORT
 
@@ -1493,13 +1507,13 @@ FORCE_INLINE void process_commands()
         #endif
         break;
       case 105: // M105
-        #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX6675)|| defined HEATER_USES_AD595
+        #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX31855)|| defined (HEATER_USES_MAX6675)|| defined HEATER_USES_AD595
           hotendtC = analog2temp(current_raw);
         #endif
         #if TEMP_1_PIN > -1 || defined BED_USES_AD595
           bedtempC = analog2tempBed(current_bed_raw);
         #endif
-        #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX6675) || defined HEATER_USES_AD595
+        #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX31855) || defined (HEATER_USES_MAX6675) || defined HEATER_USES_AD595
             showString(PSTR("ok T:"));
             Serial.print(hotendtC); 
           #ifdef PIDTEMP

--- a/Sprinter/Sprinter.pde
+++ b/Sprinter/Sprinter.pde
@@ -1922,7 +1922,7 @@ FORCE_INLINE void process_commands()
 #endif      
 #ifdef DEBUG_HEATER_TEMP
       case 601: // M601  show Extruder Temp jitter
-        #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX6675)|| defined HEATER_USES_AD595
+        #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX31855)|| defined (HEATER_USES_MAX6675)|| defined HEATER_USES_AD595
           if(current_raw_maxval > 0)
             tt_maxval = analog2temp(current_raw_maxval);
           if(current_raw_minval < 10000)  

--- a/Sprinter/heater.cpp
+++ b/Sprinter/heater.cpp
@@ -422,6 +422,10 @@ void PID_autotune(int PIDAT_test_temp)
         current_raw = read_max6675();
         PIDAT_input_help += analog2temp(current_raw);
         PIDAT_count_input++;
+	  #elif defined HEATER_USES_MAX31855
+        current_raw = read_max31855();
+        PIDAT_input_help += analog2temp(current_raw);
+        PIDAT_count_input++;		
       #endif
     }
     
@@ -637,6 +641,8 @@ void PID_autotune(int PIDAT_test_temp)
     current_raw = analogRead(TEMP_0_PIN);    
   #elif defined HEATER_USES_MAX6675
     current_raw = read_max6675();
+  #elif defined HEATER_USES_MAX31855
+    current_raw = read_max31855();
   #endif
   
   //MIN / MAX save to display the jitter of Heaterbarrel
@@ -694,7 +700,7 @@ void PID_autotune(int PIDAT_test_temp)
     }
   #endif
 
-  #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX6675) || defined (HEATER_USES_AD595)
+  #if (TEMP_0_PIN > -1) || defined (HEATER_USES_MAX31855) || defined (HEATER_USES_MAX6675) || defined (HEATER_USES_AD595)
     #ifdef PIDTEMP
       
       int current_temp = analog2temp(current_raw);
@@ -861,6 +867,13 @@ int temp2analog_max6675(int celsius)
 }
 #endif
 
+#if defined (HEATER_USES_MAX31855) || defined (BED_USES_MAX31855)
+int temp2analog_max31855(int celsius) 
+{
+    return celsius * 4;
+}
+#endif
+
 #if defined (HEATER_USES_THERMISTOR) || defined (BED_USES_THERMISTOR)
 int analog2temp_thermistor(int raw,const short table[][2], int numtemps) {
     int celsius = 0;
@@ -897,6 +910,13 @@ int analog2temp_ad595(int raw)
 
 #if defined (HEATER_USES_MAX6675) || defined (BED_USES_MAX6675)
 int analog2temp_max6675(int raw)
+{
+    return raw / 4;
+}
+#endif
+
+#if defined (HEATER_USES_MAX31855) || defined (BED_USES_MAX31855)
+int analog2temp_max31855(int raw)
 {
     return raw / 4;
 }

--- a/Sprinter/heater.cpp
+++ b/Sprinter/heater.cpp
@@ -106,8 +106,8 @@ unsigned long previous_millis_heater, previous_millis_bed_heater, previous_milli
 
 
 
-#define HEAT_INTERVAL 250
 #ifdef HEATER_USES_MAX6675
+#define HEAT_INTERVAL 250
 unsigned long max6675_previous_millis = 0;
 int max6675_temp = 2000;
 
@@ -163,6 +163,7 @@ int read_max6675()
 #endif
 
 #ifdef HEATER_USES_MAX31855
+#define HEAT_INTERVAL 120
 unsigned long max31855_previous_millis = 0;
 long max31855_temp = 2000;
 
@@ -173,7 +174,7 @@ int read_max31855()
   
   max31855_previous_millis = millis();
 
-  max31855_temp = 0;
+  max31855_temp = 0L;
     
   #ifdef	PRR
     PRR &= ~(1<<PRSPI);
@@ -190,15 +191,15 @@ int read_max31855()
   delay(1);
   
   // read MAX31855  
-  for int i = 0; i < 4; i++)
+  for(int i = 0; i < 4; i++)
   {
 	max31855_temp <<= 8;
 	SPDR = 0;
 	for (;(SPSR & (1<<SPIF)) == 0;);
 	max31855_temp |= SPDR;
   }
-	
-  // disable TT_MAX6675
+  
+  // disable TT_MAX31855
   WRITE(MAX31855_SS, 1);
 
   // validity tests

--- a/Sprinter/heater.cpp
+++ b/Sprinter/heater.cpp
@@ -201,17 +201,20 @@ int read_max31855()
   // disable TT_MAX6675
   WRITE(MAX31855_SS, 1);
 
-  if (max31855_temp & 4) 
+  // validity tests
+  if (max31855_temp & 0x3000F) 
   {
-    // thermocouple open
-    max31855_temp = 2000;
+    if(max31855_temp == 0x00000000 || max31855_temp == 0xFFFFFFFF) max31855_temp = 2016; // transmission error
+    else if(max31855_temp & 0x04) max31855_temp = 2012; // short to power
+    else if(max31855_temp & 0x02) max31855_temp = 2008; // short to ground
+    else if(max31855_temp & 0x01) max31855_temp = 2004; // no thermocouple
+    else max31855_temp = 2000; // general fault
   }
-  else 
+  else
   {
-    max31855_temp = max31855_temp >> 3;
+    max31855_temp >>= 18;
   }
-
-  return max31855_temp;
+  return int(max31855_temp);
 }
 #endif
 

--- a/Sprinter/heater.h
+++ b/Sprinter/heater.h
@@ -33,6 +33,9 @@
 #elif defined HEATER_USES_MAX6675
 #define temp2analogh( c ) temp2analog_max6675(c)
 #define analog2temp( c ) analog2temp_max6675(c)
+#elif defined HEATER_USES_MAX31855
+#define temp2analogh( c ) temp2analog_max31855(c)
+#define analog2temp( c ) analog2temp_max31855(c)
 #endif
 
 #if defined BED_USES_THERMISTOR
@@ -44,6 +47,9 @@
 #elif defined BED_USES_MAX6675
 #define temp2analogBed( c ) temp2analog_max6675(c)
 #define analog2tempBed( c ) analog2temp_max6675(c)
+#elif defined HEATER_USES_MAX31855
+#define temp2analogBed( c ) temp2analog_max31855(c)
+#define analog2tempBed( c ) analog2temp_max31855(c)
 #endif
 
 #if defined (HEATER_USES_THERMISTOR) || defined (BED_USES_THERMISTOR)
@@ -59,6 +65,11 @@ int analog2temp_ad595(int raw);
 #if defined (HEATER_USES_MAX6675) || defined (BED_USES_MAX6675)
 int temp2analog_max6675(int celsius);
 int analog2temp_max6675(int raw);
+#endif
+
+#if defined (HEATER_USES_MAX31855) || defined (BED_USES_MAX31855)
+int temp2analog_max31855(int celsius);
+int analog2temp_max31855(int raw);
 #endif
 
 

--- a/Sprinter/pins.h
+++ b/Sprinter/pins.h
@@ -722,11 +722,11 @@
 #define TEMP_0_PIN          7   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 33 extruder)
 #define TEMP_1_PIN          6   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 34 bed)
 #define SDPOWER          -1
-#define SDSS          	31
 
 #define SCK_PIN          7
 #define MISO_PIN         6
 #define MOSI_PIN         5
+#define SPI_SS           4
 #define MAX31855_SS      31
 
 #endif

--- a/Sprinter/pins.h
+++ b/Sprinter/pins.h
@@ -722,7 +722,12 @@
 #define TEMP_0_PIN          7   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 33 extruder)
 #define TEMP_1_PIN          6   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 34 bed)
 #define SDPOWER          -1
-#define SDSS          31
+#define SDSS          	31
+
+#define SCK_PIN          7
+#define MISO_PIN         6
+#define MOSI_PIN         5
+#define MAX31855_SS      31
 
 #endif
 


### PR DESCRIPTION
Added support for the MAX31855/MAX6675 thermocouple-to-digital converters to Sprinter. Should be fairly easy to add support for other electronics.
